### PR TITLE
Fix Prisma build path

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "paths": {
+      "@prisma/client": ["./node_modules/.prisma/client/index.d.ts"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- map `@prisma/client` to generated client types in `server/tsconfig.json`

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_68444dd3ff94832d9b71ae78bb0e3145