### PR TITLE
Fix React Query provider in tests

### DIFF
--- a/client/src/__tests__/ActivityList.test.tsx
+++ b/client/src/__tests__/ActivityList.test.tsx
@@ -2,6 +2,15 @@ import { screen } from '@testing-library/react';
 import ActivityList from '../components/ActivityList';
 import type { Activity } from '../api';
 import { renderWithRouter } from '../test-utils';
+import { vi } from 'vitest';
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api');
+  return {
+    ...actual,
+    useCreateActivity: () => ({ mutate: vi.fn() }),
+  };
+});
 
 describe('ActivityList', () => {
   it('renders activities', () => {

--- a/client/src/__tests__/MilestoneList.test.tsx
+++ b/client/src/__tests__/MilestoneList.test.tsx
@@ -2,6 +2,15 @@ import { screen } from '@testing-library/react';
 import MilestoneList from '../components/MilestoneList';
 import type { Milestone } from '../api';
 import { renderWithRouter } from '../test-utils';
+import { vi } from 'vitest';
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api');
+  return {
+    ...actual,
+    useCreateMilestone: () => ({ mutate: vi.fn() }),
+  };
+});
 
 describe('MilestoneList', () => {
   it('renders milestones with links', () => {

--- a/client/src/test-utils.tsx
+++ b/client/src/test-utils.tsx
@@ -1,7 +1,13 @@
 import { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 export function renderWithRouter(ui: ReactElement) {
-  return render(<MemoryRouter>{ui}</MemoryRouter>);
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
 }


### PR DESCRIPTION
## Summary
- wrap `renderWithRouter` with `QueryClientProvider`
- mock create mutations in Activity and Milestone tests

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_684459f625f4832daf3b756eb4e5ae39