### PR TITLE
Add edit/delete UI and fix startup issues

### DIFF
--- a/client/src/__tests__/ActivityList.test.tsx
+++ b/client/src/__tests__/ActivityList.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../api', async () => {
     ...actual,
     useCreateActivity: () => ({ mutate: vi.fn() }),
     useUpdateActivity: () => ({ mutate: vi.fn() }),
+    useDeleteActivity: () => ({ mutate: vi.fn() }),
   };
 });
 

--- a/client/src/__tests__/MilestoneList.test.tsx
+++ b/client/src/__tests__/MilestoneList.test.tsx
@@ -9,6 +9,8 @@ vi.mock('../api', async () => {
   return {
     ...actual,
     useCreateMilestone: () => ({ mutate: vi.fn() }),
+    useUpdateMilestone: () => ({ mutate: vi.fn() }),
+    useDeleteMilestone: () => ({ mutate: vi.fn() }),
   };
 });
 

--- a/client/src/__tests__/SubjectList.test.tsx
+++ b/client/src/__tests__/SubjectList.test.tsx
@@ -10,6 +10,8 @@ vi.mock('../api', async () => {
   return {
     ...actual,
     useCreateSubject: () => ({ mutate: vi.fn() }),
+    useUpdateSubject: () => ({ mutate: vi.fn() }),
+    useDeleteSubject: () => ({ mutate: vi.fn() }),
   };
 });
 

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -74,13 +74,88 @@ export const useCreateActivity = () => {
 export const useUpdateActivity = () => {
   const qc = useQueryClient();
   return useMutation(
-    (data: { id: number; milestoneId: number; subjectId?: number; completedAt: string | null }) =>
-      api.put(`/activities/${data.id}`, { completedAt: data.completedAt }),
+    (data: {
+      id: number;
+      milestoneId: number;
+      subjectId?: number;
+      title?: string;
+      completedAt?: string | null;
+    }) => api.put(`/activities/${data.id}`, { title: data.title, completedAt: data.completedAt }),
     {
       onSuccess: (_res, vars) => {
         qc.invalidateQueries(['milestone', vars.milestoneId]);
         if (vars.subjectId) qc.invalidateQueries(['subject', vars.subjectId]);
         qc.invalidateQueries(['subjects']);
+      },
+    },
+  );
+};
+
+export const useDeleteActivity = () => {
+  const qc = useQueryClient();
+  return useMutation(
+    (data: { id: number; milestoneId: number; subjectId?: number }) =>
+      api.delete(`/activities/${data.id}`),
+    {
+      onSuccess: (_res, vars) => {
+        qc.invalidateQueries(['milestone', vars.milestoneId]);
+        if (vars.subjectId) qc.invalidateQueries(['subject', vars.subjectId]);
+        qc.invalidateQueries(['subjects']);
+        toast.success('Activity deleted');
+      },
+    },
+  );
+};
+
+export const useUpdateSubject = () => {
+  const qc = useQueryClient();
+  return useMutation(
+    (data: { id: number; name: string }) => api.put(`/subjects/${data.id}`, { name: data.name }),
+    {
+      onSuccess: (_res, vars) => {
+        qc.invalidateQueries(['subjects']);
+        qc.invalidateQueries(['subject', vars.id]);
+        toast.success('Subject updated');
+      },
+    },
+  );
+};
+
+export const useDeleteSubject = () => {
+  const qc = useQueryClient();
+  return useMutation((id: number) => api.delete(`/subjects/${id}`), {
+    onSuccess: () => {
+      qc.invalidateQueries(['subjects']);
+      toast.success('Subject deleted');
+    },
+  });
+};
+
+export const useUpdateMilestone = () => {
+  const qc = useQueryClient();
+  return useMutation(
+    (data: { id: number; title: string; subjectId: number }) =>
+      api.put(`/milestones/${data.id}`, { title: data.title }),
+    {
+      onSuccess: (_res, vars) => {
+        qc.invalidateQueries(['milestone', vars.id]);
+        qc.invalidateQueries(['subject', vars.subjectId]);
+        qc.invalidateQueries(['subjects']);
+        toast.success('Milestone updated');
+      },
+    },
+  );
+};
+
+export const useDeleteMilestone = () => {
+  const qc = useQueryClient();
+  return useMutation(
+    (data: { id: number; subjectId: number }) => api.delete(`/milestones/${data.id}`),
+    {
+      onSuccess: (_res, vars) => {
+        qc.invalidateQueries(['subject', vars.subjectId]);
+        qc.invalidateQueries(['subjects']);
+        toast.success('Milestone deleted');
       },
     },
   );

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prepare": "husky install",
     "seed": "pnpm --filter server run seed",
     "postinstall": "cd prisma && pnpm exec prisma generate",
-    "playwright:test": "playwright test"
+    "playwright:test": "playwright test",
+    "preplaywright:test": "pnpm exec playwright install"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "start": "ts-node src/index.ts",
+    "prestart": "pnpm exec prisma generate --schema=../prisma/schema.prisma",
     "prebuild": "pnpm exec prisma generate --schema=../prisma/schema.prisma",
     "build": "tsc",
     "test": "jest",


### PR DESCRIPTION
## Summary
- trigger `prisma generate` before starting the server
- auto-install Playwright browsers before running e2e tests
- expose hooks for updating/deleting subjects, milestones, and activities
- add edit & delete actions to all lists in the React UI
- adjust unit tests for the new hooks

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm playwright:test` *(fails: missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684477f5f728832dae2d6539b7fbcf25