### PR TITLE
Update README with Playwright setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,16 @@ prisma/   # Prisma schema & migrations
 
 ## 🧪 Running Tests
 
+After running `pnpm install`, you need to download the browsers required by
+Playwright. Run `pnpm exec playwright install` (or simply execute
+`pnpm playwright:test` once, which triggers the same step automatically) before
+running the end-to-end tests.
+
 ```bash
 pnpm run test         # all tests
 pnpm test --filter server
 pnpm test --filter client
+pnpm playwright:test # end-to-end tests
 ```
 
 ## 🤝 Contributing


### PR DESCRIPTION
## Summary
- mention that Playwright browsers must be installed after `pnpm install`
- show Playwright test command in **Running Tests** section

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm playwright:test` *(fails: missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68449705aa88832d802f7ef606c9e4ba