### PR TITLE
Fix MilestoneList tests

### DIFF
--- a/client/src/__tests__/MilestoneList.test.tsx
+++ b/client/src/__tests__/MilestoneList.test.tsx
@@ -21,7 +21,7 @@ describe('MilestoneList', () => {
       { id: 2, title: 'M2', subjectId: 1, activities: [] },
     ];
 
-    renderWithRouter(<MilestoneList milestones={milestones} />);
+    renderWithRouter(<MilestoneList milestones={milestones} subjectId={1} />);
 
     expect(screen.getByText('M1')).toHaveAttribute('href', '/milestones/1');
     expect(screen.getByText('M2')).toHaveAttribute('href', '/milestones/2');


### PR DESCRIPTION
## Summary
- pass a numeric `subjectId` prop when rendering `<MilestoneList>` in tests

## Testing
- `npm test`
- `npx eslint "**/*.{ts,tsx,js,jsx}" --max-warnings 0`


------
https://chatgpt.com/codex/tasks/task_e_6844bedfc590832db8ba89c2937d9ff1