### PR TITLE
Handle Prisma P2025 on updates and deletes

### DIFF
--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import prisma from '../prisma';
 
 const router = Router();
@@ -33,9 +34,7 @@ router.post('/', async (req, res, next) => {
         durationMins: req.body.durationMins,
         privateNote: req.body.privateNote,
         publicNote: req.body.publicNote,
-        completedAt: req.body.completedAt
-          ? new Date(req.body.completedAt)
-          : undefined,
+        completedAt: req.body.completedAt ? new Date(req.body.completedAt) : undefined,
       },
     });
     res.status(201).json(activity);
@@ -53,13 +52,14 @@ router.put('/:id', async (req, res, next) => {
         durationMins: req.body.durationMins,
         privateNote: req.body.privateNote,
         publicNote: req.body.publicNote,
-        completedAt: req.body.completedAt
-          ? new Date(req.body.completedAt)
-          : undefined,
+        completedAt: req.body.completedAt ? new Date(req.body.completedAt) : undefined,
       },
     });
     res.json(activity);
   } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
     next(err);
   }
 });
@@ -69,6 +69,9 @@ router.delete('/:id', async (req, res, next) => {
     await prisma.activity.delete({ where: { id: Number(req.params.id) } });
     res.status(204).end();
   } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
     next(err);
   }
 });

--- a/server/src/routes/milestone.ts
+++ b/server/src/routes/milestone.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import prisma from '../prisma';
 
 const router = Router();
@@ -33,9 +34,7 @@ router.post('/', async (req, res, next) => {
       data: {
         title: req.body.title,
         subjectId: req.body.subjectId,
-        targetDate: req.body.targetDate
-          ? new Date(req.body.targetDate)
-          : undefined,
+        targetDate: req.body.targetDate ? new Date(req.body.targetDate) : undefined,
         estHours: req.body.estHours,
       },
     });
@@ -51,14 +50,15 @@ router.put('/:id', async (req, res, next) => {
       where: { id: Number(req.params.id) },
       data: {
         title: req.body.title,
-        targetDate: req.body.targetDate
-          ? new Date(req.body.targetDate)
-          : undefined,
+        targetDate: req.body.targetDate ? new Date(req.body.targetDate) : undefined,
         estHours: req.body.estHours,
       },
     });
     res.json(milestone);
   } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
     next(err);
   }
 });
@@ -68,6 +68,9 @@ router.delete('/:id', async (req, res, next) => {
     await prisma.milestone.delete({ where: { id: Number(req.params.id) } });
     res.status(204).end();
   } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
     next(err);
   }
 });

--- a/server/src/routes/subject.ts
+++ b/server/src/routes/subject.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import prisma from '../prisma';
 
 const router = Router();
@@ -46,6 +47,9 @@ router.put('/:id', async (req, res, next) => {
     });
     res.json(subject);
   } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
     next(err);
   }
 });
@@ -55,6 +59,9 @@ router.delete('/:id', async (req, res, next) => {
     await prisma.subject.delete({ where: { id: Number(req.params.id) } });
     res.status(204).end();
   } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
     next(err);
   }
 });


### PR DESCRIPTION
## Summary
- handle P2025 errors from Prisma on update/delete routes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bee1a4ec832db0e7c4e49398fe53