### PR TITLE
Remove tsx install from setup script

### DIFF
--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -79,9 +79,6 @@ fi
 # 8. Seed database (optional) --------------------------------------------------
 if [[ -d server ]] && [[ -f scripts/seed.ts ]]; then
   echo "🌱  Seeding database..." >&2
-  # Install tsx as a dev dependency first
-  pnpm --filter server add -D tsx
-  # Now run the seed script
   cd server
   pnpm exec tsx ../scripts/seed.ts || {
     echo "⚠️  Seed script failed (non-critical)" >&2


### PR DESCRIPTION
## Summary
- adjust codex-setup.sh seed step to assume `tsx` already present

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6844bee207a4832d917c333747122492