### PR TITLE
Support configurable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ docker compose up --build
 # open http://localhost:3000 (API) and http://localhost:5173 (UI)
 ```
 
+## 🌐 Environment Variables
+
+Set `VITE_API_URL` in `client/.env` if the API is not running on
+`http://localhost:3000/api`.
+
+```env
+VITE_API_URL=http://my-api-host/api
+```
+
+If unset, the client falls back to `http://localhost:3000/api`.
+
 ## 🗂 Project Structure
 
 ```text

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 const api = axios.create({
-  baseURL: 'http://localhost:3000/api',
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api',
 });
 
 export interface Subject {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  envPrefix: 'VITE_',
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- read base URL from `import.meta.env.VITE_API_URL`
- expose env vars in Vite config
- document `VITE_API_URL` usage

## Testing
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6844bee3a668832d8285dbf47258ddc1