### PR TITLE
Update e2e dialogs

### DIFF
--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '../../node_modules/.prisma/client';
 
 const prisma = new PrismaClient();
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -2,13 +2,16 @@ import { test, expect } from '@playwright/test';
 
 test('create subject, milestone and activity', async ({ page }) => {
   await page.goto('/subjects');
+  await page.click('text=Add Subject');
   await page.fill('input[placeholder="New subject"]', 'Playwright');
-  await page.click('button:has-text("Add")');
+  await page.click('button:has-text("Save")');
   await page.click('text=Playwright');
+  await page.click('text=Add Milestone');
   await page.fill('input[placeholder="New milestone"]', 'M1');
-  await page.click('button:has-text("Add")');
+  await page.click('button:has-text("Save")');
   await page.click('text=M1');
+  await page.click('text=Add Activity');
   await page.fill('input[placeholder="New activity"]', 'A1');
-  await page.click('button:has-text("Add")');
+  await page.click('button:has-text("Save")');
   await expect(page.locator('text=A1')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- open dialogs in the E2E test before filling forms
- adjust server prisma import to point to generated client

## Testing
- `pnpm playwright:test` *(fails: page.click timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6844c6896c54832dbda1f24d11236f33