### PR TITLE
Install Playwright dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ prisma/   # Prisma schema & migrations
 
 ## 🧪 Running Tests
 
-After running `pnpm install`, you need to download the browsers required by
-Playwright. Run `pnpm exec playwright install` (or simply execute
-`pnpm playwright:test` once, which triggers the same step automatically) before
-running the end-to-end tests.
+After running `pnpm install`, you need to download the browsers and required
+OS libraries for Playwright. Run `pnpm exec playwright install --with-deps`
+(or simply execute `pnpm playwright:test` once, which triggers the same step
+automatically) before running the end-to-end tests.
 
 Create `server/.env.test` by copying `server/.env.test.example`:
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "seed": "pnpm --filter server run seed",
     "postinstall": "cd prisma && pnpm exec prisma generate",
     "playwright:test": "playwright test",
-    "preplaywright:test": "pnpm exec playwright install"
+    "preplaywright:test": "pnpm exec playwright install --with-deps"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -58,6 +58,9 @@ fi
 echo "📦  Installing dependencies..." >&2
 pnpm install --frozen-lockfile
 
+# Install Playwright browsers and required OS dependencies
+pnpm exec playwright install --with-deps
+
 # 6. Generate Prisma client ----------------------------------------------------
 if [[ -d prisma ]]; then
   echo "🗄️  Generating Prisma client..." >&2


### PR DESCRIPTION
## Summary
- install Playwright dependencies before running tests
- run Playwright install in setup script
- document Playwright OS library installation in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d61d637c832d88f40cd0c8cadf1b