### PR TITLE
Install Playwright deps in Docker and doc test build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18 AS build
 WORKDIR /app
 COPY . .
 RUN corepack enable && pnpm install --frozen-lockfile
+RUN pnpm exec playwright install --with-deps
 RUN pnpm run build
 
 FROM node:18-slim AS runner

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ pnpm test --filter client
 pnpm playwright:test # end-to-end tests
 ```
 
+### Docker Image for Tests
+
+Build the full test image (including Playwright browsers) with:
+
+```bash
+docker build -t curriculum-planner-test .
+```
+
 ## 🤝 Contributing
 
 Copy `server/.env.test.example` to `server/.env.test` before running tests.


### PR DESCRIPTION
## Summary
- install Playwright browsers during Docker build
- explain how to build the Docker image used for tests

## Testing
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6844d62347dc832db5a320277e8c8439