### PR TITLE
Add health check route

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,9 @@ app.use(express.json());
 app.use('/api/subjects', subjectRoutes);
 app.use('/api/milestones', milestoneRoutes);
 app.use('/api/activities', activityRoutes);
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
 app.use('/api/*', (_req, res) => {
   res.status(404).json({ error: 'Not Found' });
 });

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -12,6 +12,14 @@ afterAll(async () => {
   await prisma.$disconnect();
 });
 
+describe('Health API', () => {
+  it('responds with status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});
+
 describe('Subject API', () => {
   it('creates and retrieves a subject', async () => {
     const create = await request(app).post('/api/subjects').send({ name: 'Test' });


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to express app
- test the new route returns `{status: 'ok'}`

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6844f97bcef4832d9249c73531476812