### PR TITLE
Fix Docker runtime deps and copy node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY . .
 RUN corepack enable && pnpm install --frozen-lockfile
 RUN pnpm exec playwright install --with-deps
 RUN pnpm run build
+# Remove development dependencies to keep the runtime image small
+RUN pnpm prune --prod
 
 FROM node:18-slim AS runner
 WORKDIR /app
@@ -17,6 +19,7 @@ COPY --from=build /app/server/package.json ./server/package.json
 COPY --from=build /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/server/node_modules ./server/node_modules
 EXPOSE 3000
 CMD ["sh", "-c", "pnpm exec prisma migrate deploy --schema=./prisma/schema.prisma && node server/dist/index.js"]


### PR DESCRIPTION
## Summary
- prune dev dependencies during build
- copy root node_modules to runtime image

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `docker build -t teaching-engine:test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6845043757c8832d822d0d674c050256