### PR TITLE
Fix map callback closing braces

### DIFF
--- a/client/src/components/ActivityList.tsx
+++ b/client/src/components/ActivityList.tsx
@@ -94,7 +94,8 @@ export default function ActivityList({ activities, milestoneId, subjectId }: Pro
               </div>
             </li>
           );
-        })}
+        })
+      }
       </ul>
       <Dialog open={editId !== null} onOpenChange={() => setEditId(null)}>
         <form onSubmit={handleEditSubmit} className="flex flex-col gap-2">

--- a/client/src/components/MilestoneList.tsx
+++ b/client/src/components/MilestoneList.tsx
@@ -83,7 +83,8 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
               </div>
             </li>
           );
-        })}
+        })
+      }
       </ul>
       <Dialog open={editId !== null} onOpenChange={() => setEditId(null)}>
         <form onSubmit={handleEditSubmit} className="flex flex-col gap-2">

--- a/client/src/components/SubjectList.tsx
+++ b/client/src/components/SubjectList.tsx
@@ -84,7 +84,8 @@ export default function SubjectList({ subjects }: Props) {
               </div>
             </li>
           );
-        })}
+        })
+      }
       </ul>
       <Dialog open={editId !== null} onOpenChange={() => setEditId(null)}>
         <form onSubmit={handleEditSubmit} className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- adjust ActivityList, MilestoneList and SubjectList to end `map` callbacks with `})`
- keep JSX expression closing brace on the next line

## Testing
- `pnpm lint && pnpm build && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68450ae3efac832db52db769dbde14bf