### PR TITLE
Fix lint script to fail on errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "concurrently -k --success first \"pnpm --filter server run start\" \"pnpm --filter client run dev\"",
     "build": "pnpm --filter server run build && pnpm --filter client run build",
     "test": "pnpm --filter server run test && pnpm --filter client run test",
-    "lint": "eslint \"**/*.{ts,tsx,js,jsx}\" --max-warnings 0 || true",
+    "lint": "eslint \"**/*.{ts,tsx,js,jsx}\" --max-warnings 0",
     "prepare": "husky install",
     "seed": "pnpm --filter server run seed",
     "postinstall": "cd prisma && pnpm exec prisma generate",


### PR DESCRIPTION
## Summary
- remove redundant `|| true` so eslint failures stop CI

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684517d9fdf8832d91901ea1b12eb288