### PR TITLE
Handle Playwright install failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ pnpm run test:e2e
 pnpm run test:all
 ```
 
+If the automatic Playwright installation fails (e.g., due to restricted `sudo` access in CI), install browsers and dependencies manually:
+
+```bash
+pnpm exec playwright install-deps
+pnpm exec playwright install
+```
+
 ## 📋 Usage Guide
 
 ### Basic Workflow

--- a/playwright.global-setup.ts
+++ b/playwright.global-setup.ts
@@ -1,5 +1,13 @@
 import { execSync } from 'child_process';
 
-export default async function globalSetup() {
-  execSync('pnpm exec playwright install --with-deps', { stdio: 'inherit' });
+/**
+ * Ensures Playwright browsers are installed before tests run.
+ * Skips installation if dependencies cannot be installed.
+ */
+export default async function globalSetup(): Promise<void> {
+  try {
+    execSync('pnpm exec playwright install --with-deps', { stdio: 'inherit' });
+  } catch {
+    console.warn('Playwright install failed; skipping global setup.');
+  }
 }


### PR DESCRIPTION
## Summary
- handle Playwright install errors in `playwright.global-setup.ts`
- document manual Playwright installation in `README`

## Testing
- `pnpm test && pnpm lint && pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684517f704f4832da73ea721a8638021