### PR TITLE
Implement weekly planner automation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import SubjectsPage from './pages/SubjectsPage';
 import SubjectDetailPage from './pages/SubjectDetailPage';
 import MilestoneDetailPage from './pages/MilestoneDetailPage';
+import WeeklyPlannerPage from './pages/WeeklyPlannerPage';
 
 export default function App() {
   return (
@@ -10,6 +11,7 @@ export default function App() {
       <Route path="/subjects" element={<SubjectsPage />} />
       <Route path="/subjects/:id" element={<SubjectDetailPage />} />
       <Route path="/milestones/:id" element={<MilestoneDetailPage />} />
+      <Route path="/planner" element={<WeeklyPlannerPage />} />
     </Routes>
   );
 }

--- a/client/src/__tests__/ActivitySuggestionList.test.tsx
+++ b/client/src/__tests__/ActivitySuggestionList.test.tsx
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/react';
+import ActivitySuggestionList from '../components/ActivitySuggestionList';
+import { renderWithRouter } from '../test-utils';
+
+it('renders suggestions', () => {
+  const activities = [
+    { id: 1, title: 'A1', milestoneId: 1, completedAt: null },
+    { id: 2, title: 'A2', milestoneId: 1, completedAt: null },
+  ];
+  renderWithRouter(<ActivitySuggestionList activities={activities} />);
+  expect(screen.getByText('A1')).toBeInTheDocument();
+  expect(screen.getByText('A2')).toBeInTheDocument();
+});

--- a/client/src/__tests__/WeekCalendarGrid.test.tsx
+++ b/client/src/__tests__/WeekCalendarGrid.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import WeekCalendarGrid from '../components/WeekCalendarGrid';
+import { renderWithRouter } from '../test-utils';
+
+it('calls onDrop when activity dropped', () => {
+  const handle = vi.fn();
+  const activities = { 1: { id: 1, title: 'A1', milestoneId: 1, completedAt: null } };
+  const { getAllByText } = renderWithRouter(
+    <WeekCalendarGrid schedule={[]} onDrop={handle} activities={activities} />,
+  );
+  const zone = getAllByText(/Mon/)[0].parentElement as HTMLElement;
+  fireEvent.dragOver(zone);
+  fireEvent.drop(zone, { dataTransfer: { getData: () => '1' } });
+  expect(handle).toHaveBeenCalledWith(0, 1);
+});

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -26,6 +26,19 @@ export interface Activity {
   completedAt?: string | null;
 }
 
+export interface WeeklyScheduleItem {
+  id: number;
+  day: number;
+  activityId: number;
+  activity: Activity;
+}
+
+export interface LessonPlan {
+  id: number;
+  weekStart: string;
+  schedule: WeeklyScheduleItem[];
+}
+
 export const useSubjects = () =>
   useQuery<Subject[]>({
     queryKey: ['subjects'],
@@ -158,3 +171,20 @@ export const useDeleteMilestone = () => {
     },
   });
 };
+
+export const useGeneratePlan = () =>
+  useMutation((weekStart: string) =>
+    api.post('/lesson-plans/generate', { weekStart }).then((res) => res.data as LessonPlan),
+  );
+
+export const useLessonPlan = (weekStart: string) =>
+  useQuery<LessonPlan>({
+    queryKey: ['lessonPlan', weekStart],
+    queryFn: async () => (await api.get(`/lesson-plans/${weekStart}`)).data,
+    enabled: !!weekStart,
+  });
+
+export const useSavePreferences = () =>
+  useMutation((data: { teachingStyles: string[]; pacePreference: string; prepTime: number }) =>
+    api.post('/preferences', data),
+  );

--- a/client/src/components/ActivitySuggestionList.tsx
+++ b/client/src/components/ActivitySuggestionList.tsx
@@ -1,0 +1,22 @@
+import type { Activity } from '../api';
+
+interface Props {
+  activities: Activity[];
+}
+
+export default function ActivitySuggestionList({ activities }: Props) {
+  return (
+    <ul className="space-y-2">
+      {activities.map((a) => (
+        <li
+          key={a.id}
+          draggable
+          onDragStart={(e) => e.dataTransfer.setData('text/plain', String(a.id))}
+          className="border p-2 bg-white cursor-grab"
+        >
+          {a.title}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/components/AutoFillButton.tsx
+++ b/client/src/components/AutoFillButton.tsx
@@ -1,0 +1,14 @@
+import { useGeneratePlan } from '../api';
+
+interface Props {
+  weekStart: string;
+}
+
+export default function AutoFillButton({ weekStart }: Props) {
+  const generate = useGeneratePlan();
+  return (
+    <button className="px-2 py-1 bg-blue-600 text-white" onClick={() => generate.mutate(weekStart)}>
+      Auto Fill
+    </button>
+  );
+}

--- a/client/src/components/WeekCalendarGrid.tsx
+++ b/client/src/components/WeekCalendarGrid.tsx
@@ -1,0 +1,33 @@
+import type { WeeklyScheduleItem, Activity } from '../api';
+
+interface Props {
+  schedule: WeeklyScheduleItem[];
+  onDrop: (day: number, activityId: number) => void;
+  activities: Record<number, Activity>;
+}
+
+export default function WeekCalendarGrid({ schedule, onDrop, activities }: Props) {
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  return (
+    <div className="grid grid-cols-5 gap-2">
+      {days.map((d, idx) => {
+        const item = schedule.find((s) => s.day === idx);
+        const title = item ? activities[item.activityId]?.title : '';
+        return (
+          <div
+            key={idx}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              const id = Number(e.dataTransfer.getData('text/plain'));
+              onDrop(idx, id);
+            }}
+            className="h-24 border flex items-center justify-center bg-gray-50"
+          >
+            <span>{d}</span>
+            {title && <div className="mt-2 text-sm">{title}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/pages/WeeklyPlannerPage.tsx
+++ b/client/src/pages/WeeklyPlannerPage.tsx
@@ -1,0 +1,49 @@
+import { useState, useMemo } from 'react';
+import { useLessonPlan, useSubjects, Activity } from '../api';
+import ActivitySuggestionList from '../components/ActivitySuggestionList';
+import WeekCalendarGrid from '../components/WeekCalendarGrid';
+import AutoFillButton from '../components/AutoFillButton';
+
+export default function WeeklyPlannerPage() {
+  const [weekStart, setWeekStart] = useState(() => new Date().toISOString());
+  const { data: plan, refetch } = useLessonPlan(weekStart);
+  const subjects = useSubjects().data ?? [];
+  const activities = useMemo(() => {
+    const all: Record<number, Activity> = {};
+    subjects.forEach((s) =>
+      s.milestones.forEach((m) => m.activities.forEach((a) => (all[a.id] = a))),
+    );
+    return all;
+  }, [subjects]);
+
+  const handleDrop = (day: number, activityId: number) => {
+    if (!plan) return;
+    const schedule = plan.schedule.filter((s) => s.day !== day);
+    schedule.push({ id: 0, day, activityId, activity: activities[activityId] });
+    // naive update
+    fetch(`/api/lesson-plans/${plan.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ schedule }),
+    }).then(() => refetch());
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2 items-center">
+        <input
+          type="date"
+          value={weekStart.split('T')[0]}
+          onChange={(e) => setWeekStart(new Date(e.target.value).toISOString())}
+          className="border p-1"
+        />
+        <AutoFillButton weekStart={weekStart} />
+      </div>
+      {plan && (
+        <WeekCalendarGrid schedule={plan.schedule} onDrop={handleDrop} activities={activities} />
+      )}
+      <h2>Suggestions</h2>
+      <ActivitySuggestionList activities={Object.values(activities)} />
+    </div>
+  );
+}

--- a/prisma/migrations/20250608045438_weekly_planner/migration.sql
+++ b/prisma/migrations/20250608045438_weekly_planner/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "LessonPlan" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "weekStart" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "WeeklySchedule" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "day" INTEGER NOT NULL,
+    "lessonPlanId" INTEGER NOT NULL,
+    "activityId" INTEGER NOT NULL,
+    CONSTRAINT "WeeklySchedule_lessonPlanId_fkey" FOREIGN KEY ("lessonPlanId") REFERENCES "LessonPlan" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "WeeklySchedule_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "TeacherPreferences" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "teachingStyles" TEXT NOT NULL,
+    "pacePreference" TEXT NOT NULL,
+    "prepTime" INTEGER NOT NULL
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,5 +37,30 @@ model Activity {
   privateNote  String?
   publicNote   String?
   completedAt  DateTime?
+  weeklySchedules WeeklySchedule[]
+}
+
+model LessonPlan {
+  id         Int             @id @default(autoincrement())
+  weekStart  DateTime
+  schedule   WeeklySchedule[]
+  createdAt  DateTime        @default(now())
+  updatedAt  DateTime        @updatedAt
+}
+
+model WeeklySchedule {
+  id          Int        @id @default(autoincrement())
+  day         Int
+  lessonPlanId Int
+  lessonPlan  LessonPlan @relation(fields: [lessonPlanId], references: [id])
+  activityId  Int
+  activity    Activity   @relation(fields: [activityId], references: [id])
+}
+
+model TeacherPreferences {
+  id             Int    @id @default(autoincrement())
+  teachingStyles String
+  pacePreference String
+  prepTime       Int
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import subjectRoutes from './routes/subject';
 import milestoneRoutes from './routes/milestone';
 import activityRoutes from './routes/activity';
+import lessonPlanRoutes, { savePreferences } from './routes/lessonPlan';
 import logger from './logger';
 
 const app = express();
@@ -13,6 +14,8 @@ app.use(express.json());
 app.use('/api/subjects', subjectRoutes);
 app.use('/api/milestones', milestoneRoutes);
 app.use('/api/activities', activityRoutes);
+app.use('/api/lesson-plans', lessonPlanRoutes);
+app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
 });

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -1,0 +1,102 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import prisma from '../prisma';
+
+const router = Router();
+
+// simple planning algorithm: grab first 5 incomplete activities ordered by id
+async function generateSchedule() {
+  const activities = await prisma.activity.findMany({
+    where: { completedAt: null },
+    orderBy: { id: 'asc' },
+    take: 5,
+  });
+
+  return activities.map((activity, idx) => ({
+    day: idx,
+    activityId: activity.id,
+  }));
+}
+
+router.post('/generate', async (req, res, next) => {
+  try {
+    const { weekStart } = req.body as { weekStart: string };
+    const scheduleData = await generateSchedule();
+    const plan = await prisma.lessonPlan.create({
+      data: {
+        weekStart: new Date(weekStart),
+        schedule: {
+          create: scheduleData,
+        },
+      },
+      include: { schedule: true },
+    });
+    res.status(201).json(plan);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/:weekStart', async (req, res, next) => {
+  try {
+    const plan = await prisma.lessonPlan.findFirst({
+      where: { weekStart: new Date(req.params.weekStart) },
+      include: {
+        schedule: true,
+      },
+    });
+    if (!plan) return res.status(404).json({ error: 'Not Found' });
+    res.json(plan);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const { schedule } = req.body as {
+      schedule: { id: number; day: number; activityId: number }[];
+    };
+    const plan = await prisma.lessonPlan.update({
+      where: { id: Number(req.params.id) },
+      data: {
+        schedule: {
+          deleteMany: {},
+          create: schedule.map((s) => ({ day: s.day, activityId: s.activityId })),
+        },
+      },
+      include: { schedule: true },
+    });
+    res.json(plan);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export async function savePreferences(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { teachingStyles, pacePreference, prepTime } = req.body as {
+      teachingStyles: string[];
+      pacePreference: string;
+      prepTime: number;
+    };
+    const prefs = await prisma.teacherPreferences.upsert({
+      where: { id: 1 },
+      create: {
+        id: 1,
+        teachingStyles: JSON.stringify(teachingStyles),
+        pacePreference,
+        prepTime,
+      },
+      update: {
+        teachingStyles: JSON.stringify(teachingStyles),
+        pacePreference,
+        prepTime,
+      },
+    });
+    res.status(201).json(prefs);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export default router;

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -99,3 +99,39 @@ describe('Activity API', () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe('Lesson Plan API', () => {
+  let milestoneId: number;
+
+  beforeAll(async () => {
+    const subject = await prisma.subject.create({ data: { name: 'PlanSubj' } });
+    const milestone = await prisma.milestone.create({
+      data: { title: 'PlanM', subjectId: subject.id },
+    });
+    milestoneId = milestone.id;
+    await prisma.activity.create({ data: { title: 'PlanAct', milestoneId } });
+  });
+
+  it('generates and retrieves a plan', async () => {
+    const weekStart = '2024-01-01T00:00:00.000Z';
+    const gen = await request(app).post('/api/lesson-plans/generate').send({ weekStart });
+    expect(gen.status).toBe(201);
+    const get = await request(app).get(`/api/lesson-plans/${weekStart}`);
+    expect(get.status).toBe(200);
+    expect(get.body.schedule.length).toBeGreaterThan(0);
+  });
+});
+
+describe('Preferences API', () => {
+  it('saves preferences', async () => {
+    const res = await request(app)
+      .post('/api/preferences')
+      .send({
+        teachingStyles: ['hands-on'],
+        pacePreference: 'balanced',
+        prepTime: 60,
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.pacePreference).toBe('balanced');
+  });
+});


### PR DESCRIPTION
## Summary
- add LessonPlan, WeeklySchedule and TeacherPreferences models
- implement lesson plan API with generation and preferences
- integrate planner routes into server
- create basic weekly planner UI with drag-n-drop
- expand API and component tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684516d5be58832d8dd9c9db248b578b