### PR TITLE
Fix lint failure by ignoring temporary build outputs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,6 @@ dist
 build
 coverage
 *.config.js
+
+tmp
+client/tmp


### PR DESCRIPTION
## Summary
- update `.eslintignore` to skip `tmp/` directories

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845d425279c832d86edd03600a1890e