### PR TITLE
Set busy timeout in tests using queryRawUnsafe

### DIFF
--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -3,6 +3,8 @@ import app from '../src/index';
 import prisma from '../src/prisma';
 
 beforeAll(async () => {
+  // Ensure SQLite doesn't immediately error when the database is busy
+  await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
   await prisma.activity.deleteMany();
   await prisma.milestone.deleteMany();
   await prisma.subject.deleteMany();


### PR DESCRIPTION
## Summary
- configure SQLite busy timeout in integration tests using `$queryRawUnsafe`
- rerun tests after change

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6845d236dd34832db919bca274970355