### PR TITLE
Implement resource uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ server/.env.test
 prisma/dev.db
 prisma/dev.db-journal
 server/dev-test.sqlite
+server/uploads/
 
 # Test output directories
 test-results/

--- a/client/src/__tests__/FileUpload.test.tsx
+++ b/client/src/__tests__/FileUpload.test.tsx
@@ -1,0 +1,23 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import FileUpload from '../components/FileUpload';
+import { vi } from 'vitest';
+
+const mutate = vi.fn();
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api');
+  return { ...actual, useUploadResource: () => ({ mutate }) };
+});
+
+describe('FileUpload', () => {
+  it('calls upload on click', async () => {
+    const { getByText, container } = render(<FileUpload />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+    fireEvent.click(getByText('Upload'));
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/FileUpload.tsx
+++ b/client/src/components/FileUpload.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useUploadResource } from '../api';
+
+interface Props {
+  activityId?: number;
+}
+
+export default function FileUpload({ activityId }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const upload = useUploadResource();
+
+  return (
+    <div className="space-y-2">
+      <input type="file" onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)} />
+      <button
+        className="border px-2 py-1"
+        disabled={!file}
+        onClick={() => {
+          if (file)
+            upload.mutate({
+              filename: file.name,
+              file,
+              type: file.type,
+              size: file.size,
+              activityId,
+            });
+        }}
+      >
+        Upload
+      </button>
+    </div>
+  );
+}

--- a/prisma/migrations/20250608181703_resource_materiallist/migration.sql
+++ b/prisma/migrations/20250608181703_resource_materiallist/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Resource" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "filename" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "activityId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Resource_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "MaterialList" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "weekStart" DATETIME NOT NULL,
+    "items" TEXT NOT NULL,
+    "prepared" BOOLEAN NOT NULL DEFAULT false
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Activity {
   publicNote   String?
   completedAt  DateTime?
   weeklySchedules WeeklySchedule[]
+  resources   Resource[]
 }
 
 model LessonPlan {
@@ -62,5 +63,23 @@ model TeacherPreferences {
   teachingStyles String
   pacePreference String
   prepTime       Int
+}
+
+model Resource {
+  id         Int      @id @default(autoincrement())
+  filename   String
+  url        String
+  type       String
+  size       Int
+  activityId Int?
+  activity   Activity? @relation(fields: [activityId], references: [id])
+  createdAt  DateTime @default(now())
+}
+
+model MaterialList {
+  id        Int      @id @default(autoincrement())
+  weekStart DateTime
+  items     String
+  prepared  Boolean  @default(false)
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,8 @@ import milestoneRoutes from './routes/milestone';
 import activityRoutes from './routes/activity';
 import subPlanRoutes from './routes/subplan';
 import lessonPlanRoutes, { savePreferences } from './routes/lessonPlan';
+import resourceRoutes from './routes/resource';
+import materialListRoutes from './routes/materialList';
 import logger from './logger';
 
 const app = express();
@@ -17,6 +19,8 @@ app.use('/api/milestones', milestoneRoutes);
 app.use('/api/activities', activityRoutes);
 app.use('/api/subplan', subPlanRoutes);
 app.use('/api/lesson-plans', lessonPlanRoutes);
+app.use('/api/resources', resourceRoutes);
+app.use('/api/material-lists', materialListRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
@@ -26,6 +30,7 @@ app.use('/api/*', (_req, res) => {
 });
 
 const clientDist = path.join(__dirname, '../../client/dist');
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 app.use(express.static(clientDist));
 app.get('*', (_req, res) => {
   res.sendFile(path.join(clientDist, 'index.html'));

--- a/server/src/routes/materialList.ts
+++ b/server/src/routes/materialList.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import prisma from '../prisma';
+
+const router = Router();
+
+router.get('/:weekStart', async (req, res, next) => {
+  try {
+    const list = await prisma.materialList.findFirst({
+      where: { weekStart: new Date(req.params.weekStart) },
+    });
+    if (!list) return res.status(404).json({ error: 'Not Found' });
+    res.json(list);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const { weekStart, items } = req.body as { weekStart: string; items: string[] };
+    const list = await prisma.materialList.create({
+      data: { weekStart: new Date(weekStart), items: JSON.stringify(items) },
+    });
+    res.status(201).json(list);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/src/routes/resource.ts
+++ b/server/src/routes/resource.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import prisma from '../prisma';
+import { saveFile } from '../storage';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const resources = await prisma.resource.findMany();
+    res.json(resources);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const { filename, data, type, size, activityId } = req.body as {
+      filename: string;
+      data: string;
+      type: string;
+      size: number;
+      activityId?: number;
+    };
+    if (!filename || !data) {
+      return res.status(400).json({ error: 'Invalid data' });
+    }
+    const buffer = Buffer.from(data, 'base64');
+    const url = await saveFile(filename, buffer);
+    const resource = await prisma.resource.create({
+      data: { filename, url, type, size, activityId },
+    });
+    res.status(201).json(resource);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/src/storage.ts
+++ b/server/src/storage.ts
@@ -1,0 +1,34 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+// use any to avoid requiring aws-sdk types when not installed
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let s3Client: any = null;
+const bucket = process.env.AWS_BUCKET_NAME;
+if (bucket && process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { S3Client } = require('@aws-sdk/client-s3');
+  s3Client = new S3Client({ region: process.env.AWS_REGION || 'us-east-1' });
+}
+
+const localDir = path.join(__dirname, '../uploads');
+
+/**
+ * Save a file to either local disk or S3 depending on env config.
+ * @param filename output file name
+ * @param buffer file contents
+ * @returns public URL to the stored file
+ */
+export async function saveFile(filename: string, buffer: Buffer): Promise<string> {
+  if (s3Client && bucket) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PutObjectCommand } = require('@aws-sdk/client-s3');
+    const key = `${Date.now()}-${filename}`;
+    await s3Client.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: buffer }));
+    return `https://${bucket}.s3.amazonaws.com/${key}`;
+  }
+  await fs.mkdir(localDir, { recursive: true });
+  const filePath = path.join(localDir, filename);
+  await fs.writeFile(filePath, buffer);
+  return `/uploads/${filename}`;
+}

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -135,3 +135,19 @@ describe('Preferences API', () => {
     expect(res.body.pacePreference).toBe('balanced');
   });
 });
+
+describe('Resource API', () => {
+  it('uploads and lists resources', async () => {
+    const upload = await request(app)
+      .post('/api/resources')
+      .send({
+        filename: 'test.txt',
+        data: Buffer.from('hi').toString('base64'),
+        type: 'text/plain',
+        size: 2,
+      });
+    expect(upload.status).toBe(201);
+    const list = await request(app).get('/api/resources');
+    expect(list.body.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- support S3 or local uploads via helper
- add Resource and MaterialList Prisma models
- expose upload & material list endpoints
- provide React file upload component and API hooks
- cover resource upload flow with tests

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845d2247d48832db51144dc900d9037