### PR TITLE
Add notifications and progress analytics

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,15 +3,20 @@ import SubjectsPage from './pages/SubjectsPage';
 import SubjectDetailPage from './pages/SubjectDetailPage';
 import MilestoneDetailPage from './pages/MilestoneDetailPage';
 import WeeklyPlannerPage from './pages/WeeklyPlannerPage';
+import NotificationsPage from './pages/NotificationsPage';
+import { NotificationProvider } from './contexts/NotificationContext';
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Navigate to="/subjects" replace />} />
-      <Route path="/subjects" element={<SubjectsPage />} />
-      <Route path="/subjects/:id" element={<SubjectDetailPage />} />
-      <Route path="/milestones/:id" element={<MilestoneDetailPage />} />
-      <Route path="/planner" element={<WeeklyPlannerPage />} />
-    </Routes>
+    <NotificationProvider>
+      <Routes>
+        <Route path="/" element={<Navigate to="/subjects" replace />} />
+        <Route path="/subjects" element={<SubjectsPage />} />
+        <Route path="/subjects/:id" element={<SubjectDetailPage />} />
+        <Route path="/milestones/:id" element={<MilestoneDetailPage />} />
+        <Route path="/planner" element={<WeeklyPlannerPage />} />
+        <Route path="/notifications" element={<NotificationsPage />} />
+      </Routes>
+    </NotificationProvider>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -247,3 +247,26 @@ export const useCreateMaterialList = () =>
   useMutation((data: { weekStart: string; items: string[] }) =>
     api.post('/material-lists', data).then((res) => res.data as MaterialList),
   );
+
+export interface Notification {
+  id: number;
+  message: string;
+  read: boolean;
+  createdAt: string;
+}
+
+export const useNotifications = () =>
+  useQuery<Notification[]>({
+    queryKey: ['notifications'],
+    queryFn: async () => (await api.get('/notifications')).data,
+  });
+
+export const useMarkNotificationRead = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => api.put(`/notifications/${id}/read`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+};

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -1,0 +1,20 @@
+import { useNotificationContext } from '../contexts/NotificationContext';
+
+export default function NotificationCenter() {
+  const { notifications, markRead } = useNotificationContext();
+  if (notifications.length === 0) return <div>No notifications</div>;
+  return (
+    <ul className="space-y-2">
+      {notifications.map((n) => (
+        <li key={n.id} className="border p-2 flex justify-between">
+          <span className={n.read ? 'opacity-50' : ''}>{n.message}</span>
+          {!n.read && (
+            <button className="text-sm underline" onClick={() => markRead(n.id)}>
+              Mark read
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/contexts/NotificationContext.tsx
+++ b/client/src/contexts/NotificationContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+import { useNotifications, useMarkNotificationRead, Notification } from '../api';
+
+interface NotificationContextValue {
+  notifications: Notification[];
+  markRead: (id: number) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue>({} as NotificationContextValue);
+
+export function NotificationProvider({ children }: { children: React.ReactNode }) {
+  const { data = [] } = useNotifications();
+  const markMutation = useMarkNotificationRead();
+  const markRead = (id: number) => markMutation.mutate(id);
+  return (
+    <NotificationContext.Provider value={{ notifications: data, markRead }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export const useNotificationContext = () => useContext(NotificationContext);

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -1,0 +1,10 @@
+import NotificationCenter from '../components/NotificationCenter';
+
+export default function NotificationsPage() {
+  return (
+    <div>
+      <h1>Notifications</h1>
+      <NotificationCenter />
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,12 @@ importers:
       express:
         specifier: 4.21.2
         version: 4.21.2
+      node-cron:
+        specifier: ^3.0.3
+        version: 3.0.3
+      nodemailer:
+        specifier: ^6.9.11
+        version: 6.10.1
       pdfkit:
         specifier: ^0.17.1
         version: 0.17.1
@@ -152,6 +158,12 @@ importers:
       '@types/node':
         specifier: ^18.18.0
         version: 18.19.111
+      '@types/node-cron':
+        specifier: ^3.0.3
+        version: 3.0.11
+      '@types/nodemailer':
+        specifier: ^6.4.15
+        version: 6.4.17
       '@types/pdfkit':
         specifier: ^0.13.9
         version: 0.13.9
@@ -1910,10 +1922,22 @@ packages:
         integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==,
       }
 
+  '@types/node-cron@3.0.11':
+    resolution:
+      {
+        integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==,
+      }
+
   '@types/node@18.19.111':
     resolution:
       {
         integrity: sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==,
+      }
+
+  '@types/nodemailer@6.4.17':
+    resolution:
+      {
+        integrity: sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==,
       }
 
   '@types/pdfkit@0.13.9':
@@ -4787,6 +4811,13 @@ packages:
       }
     engines: { node: '>= 0.6' }
 
+  node-cron@3.0.3:
+    resolution:
+      {
+        integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==,
+      }
+    engines: { node: '>=6.0.0' }
+
   node-int64@0.4.0:
     resolution:
       {
@@ -4798,6 +4829,13 @@ packages:
       {
         integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==,
       }
+
+  nodemailer@6.10.1:
+    resolution:
+      {
+        integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==,
+      }
+    engines: { node: '>=6.0.0' }
 
   normalize-path@3.0.0:
     resolution:
@@ -6385,6 +6423,13 @@ packages:
       }
     engines: { node: '>= 0.4.0' }
 
+  uuid@8.3.2:
+    resolution:
+      {
+        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
+      }
+    hasBin: true
+
   v8-compile-cache-lib@3.0.1:
     resolution:
       {
@@ -7712,9 +7757,15 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
+  '@types/node-cron@3.0.11': {}
+
   '@types/node@18.19.111':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/nodemailer@6.4.17':
+    dependencies:
+      '@types/node': 18.19.111
 
   '@types/pdfkit@0.13.9':
     dependencies:
@@ -9706,9 +9757,15 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  node-cron@3.0.3:
+    dependencies:
+      uuid: 8.3.2
+
   node-int64@0.4.0: {}
 
   node-releases@2.0.19: {}
+
+  nodemailer@6.10.1: {}
 
   normalize-path@3.0.0: {}
 
@@ -10638,6 +10695,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/prisma/migrations/20250608185952_notifications/migration.sql
+++ b/prisma/migrations/20250608185952_notifications/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "message" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,3 +83,10 @@ model MaterialList {
   prepared  Boolean  @default(false)
 }
 
+model Notification {
+  id        Int      @id @default(autoincrement())
+  message   String
+  read      Boolean  @default(false)
+  createdAt DateTime @default(now())
+}
+

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,9 @@
     "pdfkit": "^0.17.1",
     "pino": "8.21.0",
     "prisma": "6.9.0",
-    "zod": "3.25.56"
+    "zod": "3.25.56",
+    "node-cron": "^3.0.3",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",
@@ -27,6 +29,8 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^18.18.0",
     "@types/pdfkit": "^0.13.9",
+    "@types/node-cron": "^3.0.3",
+    "@types/nodemailer": "^6.4.15",
     "@types/supertest": "^2.0.12",
     "dotenv": "^16.5.0",
     "jest": "^29.7.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,8 @@ import subPlanRoutes from './routes/subplan';
 import lessonPlanRoutes, { savePreferences } from './routes/lessonPlan';
 import resourceRoutes from './routes/resource';
 import materialListRoutes from './routes/materialList';
+import notificationRoutes from './routes/notification';
+import { scheduleProgressCheck } from './jobs/progressCheck';
 import logger from './logger';
 
 const app = express();
@@ -21,6 +23,7 @@ app.use('/api/subplan', subPlanRoutes);
 app.use('/api/lesson-plans', lessonPlanRoutes);
 app.use('/api/resources', resourceRoutes);
 app.use('/api/material-lists', materialListRoutes);
+app.use('/api/notifications', notificationRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
@@ -51,6 +54,7 @@ app.use(
 
 const PORT = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
+  scheduleProgressCheck();
   app.listen(PORT, () => {
     logger.info(`Server listening on port ${PORT}`);
   });

--- a/server/src/jobs/progressCheck.ts
+++ b/server/src/jobs/progressCheck.ts
@@ -1,0 +1,27 @@
+import cron from 'node-cron';
+import prisma from '../prisma';
+import { sendEmail } from '../services/emailService';
+
+export async function runProgressCheck() {
+  const today = new Date();
+  const soon = new Date();
+  soon.setDate(today.getDate() + 7);
+  const milestones = await prisma.milestone.findMany({
+    where: {
+      targetDate: { not: null, lte: soon },
+    },
+    include: { activities: true, subject: true },
+  });
+  for (const m of milestones) {
+    const incomplete = m.activities.filter((a) => !a.completedAt).length;
+    if (incomplete > 0) {
+      const message = `Milestone "${m.title}" is due soon`;
+      await prisma.notification.create({ data: { message } });
+      await sendEmail('teacher@example.com', 'Milestone Alert', message);
+    }
+  }
+}
+
+export function scheduleProgressCheck() {
+  cron.schedule('0 6 * * *', runProgressCheck);
+}

--- a/server/src/routes/notification.ts
+++ b/server/src/routes/notification.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import prisma from '../prisma';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const notes = await prisma.notification.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+    res.json(notes);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const { message } = req.body as { message: string };
+    if (!message) return res.status(400).json({ error: 'Invalid data' });
+    const note = await prisma.notification.create({ data: { message } });
+    res.status(201).json(note);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id/read', async (req, res, next) => {
+  try {
+    const note = await prisma.notification.update({
+      where: { id: Number(req.params.id) },
+      data: { read: true },
+    });
+    res.json(note);
+  } catch (err) {
+    if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
+    next(err);
+  }
+});
+
+export default router;

--- a/server/src/services/emailService.ts
+++ b/server/src/services/emailService.ts
@@ -1,0 +1,26 @@
+import nodemailer from 'nodemailer';
+
+let transporter: nodemailer.Transporter | null = null;
+
+if (process.env.SMTP_HOST) {
+  transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT || 587),
+    auth: process.env.SMTP_USER
+      ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+      : undefined,
+  });
+}
+
+export async function sendEmail(to: string, subject: string, text: string) {
+  if (!transporter) {
+    console.log('Email:', { to, subject, text });
+    return;
+  }
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || 'no-reply@example.com',
+    to,
+    subject,
+    text,
+  });
+}

--- a/server/src/services/progressAnalytics.ts
+++ b/server/src/services/progressAnalytics.ts
@@ -1,0 +1,22 @@
+import prisma from '../prisma';
+
+export interface MilestoneProgress {
+  id: number;
+  title: string;
+  completionRate: number;
+  targetDate?: Date | null;
+}
+
+export async function getMilestoneProgress(): Promise<MilestoneProgress[]> {
+  const milestones = await prisma.milestone.findMany({ include: { activities: true } });
+  return milestones.map((m) => {
+    const total = m.activities.length;
+    const completed = m.activities.filter((a) => a.completedAt !== null).length;
+    return {
+      id: m.id,
+      title: m.title,
+      completionRate: total === 0 ? 0 : completed / total,
+      targetDate: m.targetDate,
+    };
+  });
+}

--- a/server/tests/alerts.test.ts
+++ b/server/tests/alerts.test.ts
@@ -1,0 +1,37 @@
+import prisma from '../src/prisma';
+import { runProgressCheck } from '../src/jobs/progressCheck';
+
+beforeAll(async () => {
+  await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
+  await prisma.weeklySchedule.deleteMany();
+  await prisma.lessonPlan.deleteMany();
+  await prisma.notification.deleteMany();
+  await prisma.activity.deleteMany();
+  await prisma.milestone.deleteMany();
+  await prisma.subject.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.weeklySchedule.deleteMany();
+  await prisma.lessonPlan.deleteMany();
+  await prisma.notification.deleteMany();
+  await prisma.activity.deleteMany();
+  await prisma.milestone.deleteMany();
+  await prisma.subject.deleteMany();
+  await prisma.$disconnect();
+});
+
+describe('progress alerts', () => {
+  it('creates notification when milestone due soon', async () => {
+    const subj = await prisma.subject.create({ data: { name: 'N' } });
+    const milestone = await prisma.milestone.create({
+      data: { title: 'M', subjectId: subj.id, targetDate: new Date() },
+    });
+    await prisma.activity.create({ data: { title: 'A', milestoneId: milestone.id } });
+
+    await runProgressCheck();
+    const notes = await prisma.notification.findMany();
+    expect(notes.length).toBe(1);
+    expect(notes[0].message).toContain('Milestone');
+  });
+});

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -5,12 +5,18 @@ import prisma from '../src/prisma';
 beforeAll(async () => {
   // Ensure SQLite doesn't immediately error when the database is busy
   await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
+  await prisma.weeklySchedule.deleteMany();
+  await prisma.lessonPlan.deleteMany();
+  await prisma.notification.deleteMany();
   await prisma.activity.deleteMany();
   await prisma.milestone.deleteMany();
   await prisma.subject.deleteMany();
 });
 
 afterAll(async () => {
+  await prisma.weeklySchedule.deleteMany();
+  await prisma.lessonPlan.deleteMany();
+  await prisma.notification.deleteMany();
   await prisma.$disconnect();
 });
 


### PR DESCRIPTION
## Summary
- add Notification model and migration
- create email and progress analytics services
- run daily progress check cron job
- expose notifications API and React pages
- test alert creation logic

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845dc84dc34832da6b2dfa91353ba72