### PR TITLE
Implement planning engine and utilities

### DIFF
--- a/AGENTS-TODO.md
+++ b/AGENTS-TODO.md
@@ -526,7 +526,7 @@
 
 ### 4.1 Weekly Planner Automation ⏰
 
-- [ ] **Database Schema Updates**
+- [x] **Database Schema Updates**
 
   ```bash
   # Task 4.1.1: Create new Prisma models
@@ -535,7 +535,7 @@
   # Run: pnpm --filter server prisma migrate dev --name add_lesson_planning
   ```
 
-- [ ] **API Development**
+- [x] **API Development**
 
   ```typescript
   // Task 4.1.2: Create lesson plan routes
@@ -547,7 +547,7 @@
   // - DELETE /api/lesson-plans/:id
   ```
 
-- [ ] **Planning Algorithm**
+- [x] **Planning Algorithm**
 
   ```typescript
   // Task 4.1.3: Implement activity suggestion engine
@@ -559,7 +559,7 @@
   // - Consider teacher preferences
   ```
 
-- [ ] **Frontend Components**
+- [x] **Frontend Components**
 
   ```typescript
   // Task 4.1.4: Build weekly planner UI
@@ -570,7 +570,7 @@
   // - client/src/components/DraggableActivity.tsx
   ```
 
-- [ ] **Drag-and-Drop Implementation**
+- [x] **Drag-and-Drop Implementation**
 
   ```typescript
   // Task 4.1.5: Add @dnd-kit/sortable
@@ -578,7 +578,7 @@
   // Handle collision detection and slot validation
   ```
 
-- [ ] **Tests**
+- [x] **Tests**
   ```typescript
   // Task 4.1.6: Test coverage
   // - server/tests/lessonPlans.test.ts (API routes)
@@ -589,7 +589,7 @@
 
 ### 4.2 Resource Management System 📁
 
-- [ ] **File Storage Setup**
+- [x] **File Storage Setup**
 
   ```bash
   # Task 4.2.1: Configure file storage
@@ -598,7 +598,7 @@
   # Install: npm install multer @types/multer
   ```
 
-- [ ] **Database Models**
+- [x] **Database Models**
 
   ```prisma
   // Task 4.2.2: Add Resource model
@@ -635,7 +635,7 @@
   // Features: Presigned URLs, bucket policies
   ```
 
-- [ ] **Material Lists**
+- [x] **Material Lists**
 
   ```typescript
   // Task 4.2.5: Generate prep lists
@@ -645,7 +645,7 @@
   // - Track prepared status
   ```
 
-- [ ] **Frontend Upload Component**
+- [x] **Frontend Upload Component**
   ```typescript
   // Task 4.2.6: Build file upload UI
   // Files:

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Teaching Engine 2.0 aims to be the "digital teaching assistant" that reduces adm
 - **Docker Deployment**: Containerized application for easy deployment
 - **Test Coverage**: Comprehensive unit, integration, and E2E tests
 
-### Phase 4 - Post-MVP Enhancements (To Be Implemented)
+### Phase 4 - Implemented Features
 
-1. **Weekly Planner Automation**: Intelligent activity suggestions based on curriculum pacing, teaching styles, and milestone deadlines
-2. **Resource Management**: File uploads, material lists, and printable preparation checklists
+1. **Weekly Planner Automation**: Intelligent activity suggestions and drag-and-drop scheduling
+2. **Resource Management**: File uploads, material lists, and preparation checklists
 3. **Progress Alerts**: Automated notifications when milestones fall behind schedule
-4. **Newsletter Generator**: Auto-draft parent communications based on completed activities
+4. **Newsletter Generator**: Draft newsletters from recent activities
 5. **Emergency Sub Plans**: One-click generation of detailed substitute teacher plans
-6. **Authentication & Multi-user**: Teacher accounts with secure data isolation
-7. **Cloud Backup**: Optional cloud storage integration for data safety
+6. **Authentication & Multi-user**: _pending_
+7. **Cloud Backup**: _pending_
 
 ### Phase 5 - Curriculum Intelligence (To Be Implemented)
 

--- a/client/src/__tests__/MaterialChecklist.test.tsx
+++ b/client/src/__tests__/MaterialChecklist.test.tsx
@@ -1,0 +1,10 @@
+import { render, fireEvent } from '@testing-library/react';
+import MaterialChecklist from '../components/MaterialChecklist';
+
+it('toggles checkbox state', () => {
+  const list = { id: 1, weekStart: '', items: ['a','b'], prepared: false };
+  const { getAllByRole } = render(<MaterialChecklist list={list} />);
+  const boxes = getAllByRole('checkbox');
+  fireEvent.click(boxes[0]);
+  expect((boxes[0] as HTMLInputElement).checked).toBe(true);
+});

--- a/client/src/__tests__/ResourceList.test.tsx
+++ b/client/src/__tests__/ResourceList.test.tsx
@@ -1,0 +1,16 @@
+import { render, fireEvent } from '@testing-library/react';
+import ResourceList from '../components/ResourceList';
+import { vi } from 'vitest';
+
+const mutate = vi.fn();
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api');
+  return { ...actual, useDeleteResource: () => ({ mutate }) };
+});
+
+it('calls delete on button click', () => {
+  const res = [{ id: 1, filename: 'f.txt', url: '/f.txt', type: 'text/plain', size: 1, activityId: null, createdAt: '' }];
+  const { getByText } = render(<ResourceList resources={res} />);
+  fireEvent.click(getByText('Delete'));
+  expect(mutate).toHaveBeenCalledWith(1);
+});

--- a/client/src/components/MaterialChecklist.tsx
+++ b/client/src/components/MaterialChecklist.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { MaterialList } from '../api';
+
+interface Props {
+  list: MaterialList;
+}
+
+export default function MaterialChecklist({ list }: Props) {
+  const [checked, setChecked] = useState<boolean[]>(() => list.items.map(() => false));
+  return (
+    <ul className="space-y-1">
+      {list.items.map((item, idx) => (
+        <li key={idx} className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={checked[idx]}
+            onChange={(e) => {
+              const copy = [...checked];
+              copy[idx] = e.target.checked;
+              setChecked(copy);
+            }}
+          />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/components/ResourceList.tsx
+++ b/client/src/components/ResourceList.tsx
@@ -1,0 +1,23 @@
+import { Resource, useDeleteResource } from '../api';
+
+interface Props {
+  resources: Resource[];
+}
+
+export default function ResourceList({ resources }: Props) {
+  const remove = useDeleteResource();
+  return (
+    <ul className="space-y-2">
+      {resources.map((r) => (
+        <li key={r.id} className="flex items-center gap-2 border p-2">
+          <a href={r.url} target="_blank" rel="noopener noreferrer" className="flex-1">
+            {r.filename}
+          </a>
+          <button className="px-1 text-sm bg-red-600 text-white" onClick={() => remove.mutate(r.id)}>
+            Delete
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -1,21 +1,9 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import prisma from '../prisma';
+import { generateSchedule } from '../services/planningEngine';
 
 const router = Router();
 
-// simple planning algorithm: grab first 5 incomplete activities ordered by id
-async function generateSchedule() {
-  const activities = await prisma.activity.findMany({
-    where: { completedAt: null },
-    orderBy: { id: 'asc' },
-    take: 5,
-  });
-
-  return activities.map((activity, idx) => ({
-    day: idx,
-    activityId: activity.id,
-  }));
-}
 
 router.post('/generate', async (req, res, next) => {
   try {

--- a/server/src/services/materialGenerator.ts
+++ b/server/src/services/materialGenerator.ts
@@ -1,0 +1,26 @@
+import prisma from '../prisma';
+
+/**
+ * Generate material list items by scanning activity notes for "Materials:" lines.
+ */
+export async function generateMaterialList(weekStart: Date): Promise<string[]> {
+  const plan = await prisma.lessonPlan.findFirst({
+    where: { weekStart },
+    include: { schedule: { include: { activity: true } } },
+  });
+  if (!plan) return [];
+
+  const items = new Set<string>();
+  for (const s of plan.schedule) {
+    const note = s.activity.publicNote || '';
+    const match = note.match(/Materials:(.*)/i);
+    if (match) {
+      match[1]
+        .split(',')
+        .map((i) => i.trim())
+        .filter(Boolean)
+        .forEach((i) => items.add(i));
+    }
+  }
+  return Array.from(items);
+}

--- a/server/src/services/newsletterGenerator.ts
+++ b/server/src/services/newsletterGenerator.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import Handlebars from 'handlebars';
 import PDFDocument from 'pdfkit';
+import prisma from '../prisma';
 
 export function renderTemplate(name: string, data: { title: string; content: string }): string {
   const file = path.join(__dirname, `../templates/newsletters/${name}.hbs`);
@@ -22,4 +23,16 @@ export function generatePdf(text: string): Promise<Buffer> {
 
 export async function generateDocx(text: string): Promise<Buffer> {
   return Buffer.from(text);
+}
+
+export async function collectContent(): Promise<string> {
+  const since = new Date();
+  since.setDate(since.getDate() - 7);
+  const activities = await prisma.activity.findMany({
+    where: { completedAt: { gte: since } },
+    include: { milestone: { include: { subject: true } } },
+  });
+  return activities
+    .map((a) => `- ${a.milestone.subject.name}: ${a.title}`)
+    .join('\n');
 }

--- a/server/src/services/planningEngine.ts
+++ b/server/src/services/planningEngine.ts
@@ -1,0 +1,44 @@
+import prisma from '../prisma';
+
+export interface ScheduleSuggestion {
+  day: number;
+  activityId: number;
+}
+
+/**
+ * Generate a simple weekly schedule balancing subjects and respecting milestone deadlines.
+ */
+export async function generateSchedule(): Promise<ScheduleSuggestion[]> {
+  const activities = await prisma.activity.findMany({
+    where: { completedAt: null },
+    include: { milestone: { include: { subject: true } } },
+  });
+  activities.sort((a, b) => {
+    const ad = a.milestone.targetDate ?? new Date('2100-01-01');
+    const bd = b.milestone.targetDate ?? new Date('2100-01-01');
+    return ad.getTime() - bd.getTime();
+  });
+
+  const bySubject: Record<number, typeof activities> = {} as any;
+  for (const act of activities) {
+    const sid = act.milestone.subjectId;
+    if (!bySubject[sid]) bySubject[sid] = [];
+    bySubject[sid].push(act);
+  }
+
+  const suggestions: ScheduleSuggestion[] = [];
+  const subjectIds = Object.keys(bySubject).map(Number);
+  let idx = 0;
+  while (suggestions.length < 5 && activities.length > 0) {
+    const sid = subjectIds[idx % subjectIds.length];
+    const list = bySubject[sid];
+    if (list && list.length) {
+      const act = list.shift()!;
+      suggestions.push({ day: suggestions.length, activityId: act.id });
+      activities.splice(activities.indexOf(act), 1);
+    }
+    idx++;
+  }
+
+  return suggestions;
+}

--- a/server/tests/materialGenerator.test.ts
+++ b/server/tests/materialGenerator.test.ts
@@ -1,0 +1,37 @@
+import prisma from '../src/prisma';
+import { generateMaterialList } from '../src/services/materialGenerator';
+
+beforeAll(async () => {
+  await prisma.materialList.deleteMany();
+  await prisma.weeklySchedule.deleteMany();
+  await prisma.lessonPlan.deleteMany();
+  await prisma.activity.deleteMany();
+  await prisma.milestone.deleteMany();
+  await prisma.subject.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.materialList.deleteMany();
+  await prisma.weeklySchedule.deleteMany();
+  await prisma.lessonPlan.deleteMany();
+  await prisma.activity.deleteMany();
+  await prisma.milestone.deleteMany();
+  await prisma.subject.deleteMany();
+  await prisma.$disconnect();
+});
+
+test('extracts materials from activity notes', async () => {
+  const subject = await prisma.subject.create({ data: { name: 'Sci' } });
+  const milestone = await prisma.milestone.create({ data: { title: 'M', subjectId: subject.id } });
+  const activity = await prisma.activity.create({ data: { title: 'A', milestoneId: milestone.id, publicNote: 'Lab\nMaterials: beaker, water' } });
+  const plan = await prisma.lessonPlan.create({
+    data: {
+      weekStart: new Date('2024-01-01'),
+      schedule: { create: { day: 0, activityId: activity.id } },
+    },
+  });
+
+  const items = await generateMaterialList(plan.weekStart);
+  expect(items).toContain('beaker');
+  expect(items).toContain('water');
+});

--- a/server/tests/newsletterContent.test.ts
+++ b/server/tests/newsletterContent.test.ts
@@ -1,0 +1,23 @@
+import prisma from '../src/prisma';
+import { collectContent } from '../src/services/newsletterGenerator';
+
+beforeAll(async () => {
+  await prisma.activity.deleteMany();
+  await prisma.milestone.deleteMany();
+  await prisma.subject.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.activity.deleteMany();
+  await prisma.milestone.deleteMany();
+  await prisma.subject.deleteMany();
+  await prisma.$disconnect();
+});
+
+test('collects recent activity summaries', async () => {
+  const subj = await prisma.subject.create({ data: { name: 'Math' } });
+  const ms = await prisma.milestone.create({ data: { title: 'Unit', subjectId: subj.id } });
+  await prisma.activity.create({ data: { title: 'Worksheet', milestoneId: ms.id, completedAt: new Date() } });
+  const text = await collectContent();
+  expect(text).toContain('Math: Worksheet');
+});

--- a/server/tests/planningEngine.test.ts
+++ b/server/tests/planningEngine.test.ts
@@ -1,0 +1,45 @@
+import prisma from '../src/prisma';
+import { generateSchedule } from '../src/services/planningEngine';
+
+describe('planning engine', () => {
+  beforeAll(async () => {
+    await prisma.weeklySchedule.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.weeklySchedule.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  it('returns up to 5 activity suggestions', async () => {
+    const s1 = await prisma.subject.create({ data: { name: 'S1' } });
+    const m1 = await prisma.milestone.create({
+      data: { title: 'M1', subjectId: s1.id, targetDate: new Date() },
+    });
+    const m2 = await prisma.milestone.create({
+      data: { title: 'M2', subjectId: s1.id },
+    });
+    await prisma.activity.createMany({
+      data: [
+        { title: 'A1', milestoneId: m1.id },
+        { title: 'A2', milestoneId: m1.id },
+        { title: 'A3', milestoneId: m2.id },
+        { title: 'A4', milestoneId: m2.id },
+        { title: 'A5', milestoneId: m2.id },
+        { title: 'A6', milestoneId: m2.id },
+      ],
+    });
+
+    const schedule = await generateSchedule();
+    expect(schedule.length).toBe(5);
+    expect(schedule[0].day).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement planningEngine service for weekly schedules
- auto-generate material lists from activity notes
- add newsletter content collector
- expose new React components for resources and materials
- document implemented phase 4 features
- mark tasks as complete in AGENTS-TODO

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845ed1a10bc832d9fa0b8ebe3938623