### PR TITLE
Add labels to activity checkboxes

### DIFF
--- a/client/src/__tests__/ActivityList.test.tsx
+++ b/client/src/__tests__/ActivityList.test.tsx
@@ -26,4 +26,16 @@ describe('ActivityList', () => {
     expect(screen.getByText('A1')).toBeInTheDocument();
     expect(screen.getByText('A2')).toBeInTheDocument();
   });
+
+  it('associates checkboxes with accessible labels', () => {
+    const activities: Activity[] = [{ id: 1, title: 'A1', milestoneId: 1, completedAt: null }];
+
+    renderWithRouter(<ActivityList activities={activities} milestoneId={1} />);
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /mark a1 completed/i,
+    });
+
+    expect(checkbox).toBeInTheDocument();
+  });
 });

--- a/client/src/components/ActivityList.tsx
+++ b/client/src/components/ActivityList.tsx
@@ -59,10 +59,12 @@ export default function ActivityList({ activities, milestoneId, subjectId }: Pro
       <ul className="space-y-2">
         {activities.map((a) => {
           const progress = a.completedAt ? 100 : 0;
+          const checkboxId = `activity-${a.id}-checkbox`;
           return (
             <li key={a.id} className="border p-2 rounded space-y-1">
               <div className="flex items-center gap-2">
                 <input
+                  id={checkboxId}
                   type="checkbox"
                   checked={!!a.completedAt}
                   onChange={(e) =>
@@ -74,6 +76,9 @@ export default function ActivityList({ activities, milestoneId, subjectId }: Pro
                     })
                   }
                 />
+                <label htmlFor={checkboxId} className="sr-only">
+                  Mark {a.title} completed
+                </label>
                 <span className="flex-1">{a.title}</span>
                 <div className="flex gap-1">
                   <button


### PR DESCRIPTION
## Summary
- make ActivityList checkboxes accessible with id+label
- add tests for checkbox labels

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845f5a99094832d83c90ce116a21c0f