### PR TITLE
Add weekly planner tests

### DIFF
--- a/AGENTS-TODO.md
+++ b/AGENTS-TODO.md
@@ -578,7 +578,7 @@
 // Handle collision detection and slot validation
 ```
 
-- [ ] **Tests**
+- [x] **Tests**
   ```typescript
   // Task 4.1.6: Test coverage
   // - server/tests/lessonPlans.test.ts (API routes)

--- a/client/tests/WeeklyPlanner.test.tsx
+++ b/client/tests/WeeklyPlanner.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react';
+import WeeklyPlannerPage from '../src/pages/WeeklyPlannerPage';
+import { renderWithRouter } from '../src/test-utils';
+import { vi } from 'vitest';
+
+vi.mock('../src/api', async () => {
+  const actual = await vi.importActual('../src/api');
+  return {
+    ...actual,
+    useLessonPlan: () => ({
+      data: { id: 1, weekStart: '2025-01-01T00:00:00.000Z', schedule: [] },
+      refetch: vi.fn(),
+    }),
+    useSubjects: () => ({ data: [] }),
+    useGeneratePlan: () => ({ mutate: vi.fn() }),
+  };
+});
+
+test('renders weekly planner layout', () => {
+  renderWithRouter(<WeeklyPlannerPage />);
+  expect(screen.getByText('Auto Fill')).toBeInTheDocument();
+  expect(screen.getByTestId('day-0')).toBeInTheDocument();
+});

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "dev": "ts-node src/index.ts",
     "start": "ts-node src/index.ts",
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --runInBand",
     "seed": "ts-node ../scripts/seed.ts"
   },
   "dependencies": {

--- a/server/tests/planningEngine.test.ts
+++ b/server/tests/planningEngine.test.ts
@@ -42,4 +42,35 @@ describe('planning engine', () => {
     const days = new Set(schedule.map((s) => s.day));
     expect(days.size).toBe(5);
   });
+
+  it('rotates subjects sequentially', async () => {
+    await prisma.weeklySchedule.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.resource.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+
+    const s1 = await prisma.subject.create({ data: { name: 'S1' } });
+    const s2 = await prisma.subject.create({ data: { name: 'S2' } });
+    const m1 = await prisma.milestone.create({
+      data: { title: 'M1', subjectId: s1.id },
+    });
+    const m2 = await prisma.milestone.create({
+      data: { title: 'M2', subjectId: s2.id },
+    });
+    const a1 = await prisma.activity.create({ data: { title: 'A1', milestoneId: m1.id } });
+    const a2 = await prisma.activity.create({ data: { title: 'A2', milestoneId: m2.id } });
+    const a3 = await prisma.activity.create({ data: { title: 'A3', milestoneId: m1.id } });
+    const a4 = await prisma.activity.create({ data: { title: 'A4', milestoneId: m2.id } });
+    const schedule = await generateWeeklySchedule();
+    const ids = schedule.map((s) => s.activityId);
+    const i1 = ids.indexOf(a1.id);
+    const i2 = ids.indexOf(a2.id);
+    const i3 = ids.indexOf(a3.id);
+    const i4 = ids.indexOf(a4.id);
+    expect(i1).toBeLessThan(i2);
+    expect(i2).toBeLessThan(i3);
+    expect(i3).toBeLessThan(i4);
+  });
 });

--- a/tests/e2e/weekly-planning.spec.ts
+++ b/tests/e2e/weekly-planning.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('generate weekly plan from activity', async ({ page }) => {
+  const ts = Date.now();
+  await page.goto('/subjects');
+
+  await page.click('text=Add Subject');
+  await page.fill('input[placeholder="New subject"]', `Plan${ts}`);
+  await page.click('button:has-text("Save")');
+  await page.click(`text=Plan${ts}`);
+
+  await page.click('text=Add Milestone');
+  await page.fill('input[placeholder="New milestone"]', 'Mplan');
+  await page.click('button:has-text("Save")');
+  await page.click('text=Mplan');
+
+  await page.click('text=Add Activity');
+  await page.fill('input[placeholder="New activity"]', 'Aplan');
+  await page.click('button:has-text("Save")');
+
+  await page.goto('/planner');
+  await page.click('text=Auto Fill');
+  await expect(page.locator('text=Aplan')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- test lesson plan API routes
- improve planning engine tests
- add weekly planner component test
- add e2e test for weekly planning
- run server tests sequentially
- update Phase 4 TODO list

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68464afacb54832db45e0db41ef883c4