### PR TITLE
Handle lesson plan 404 gracefully

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -195,9 +195,19 @@ export const useGeneratePlan = () =>
   );
 
 export const useLessonPlan = (weekStart: string) =>
-  useQuery<LessonPlan>({
+  useQuery<LessonPlan | undefined>({
     queryKey: ['lessonPlan', weekStart],
-    queryFn: async () => (await api.get(`/lesson-plans/${weekStart}`)).data,
+    queryFn: async () => {
+      try {
+        const res = await api.get(`/lesson-plans/${weekStart}`);
+        return res.data as LessonPlan;
+      } catch (err) {
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          return undefined;
+        }
+        throw err;
+      }
+    },
     enabled: !!weekStart,
   });
 


### PR DESCRIPTION
## Summary
- return `undefined` when fetching a lesson plan that doesn't exist
- reset mock lesson plan data in WeeklyPlanner tests
- verify WeeklyPlanner renders correctly with no plan

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684655665bac832db235ad8ed920d5bc