### PR TITLE
Validate newsletter templates

### DIFF
--- a/server/src/routes/newsletter.ts
+++ b/server/src/routes/newsletter.ts
@@ -20,7 +20,15 @@ router.post('/', async (req, res, next) => {
       content: string;
       template?: string;
     };
-    const html = renderTemplate(template ?? 'weekly', { title, content });
+    let html: string;
+    try {
+      html = renderTemplate(template ?? 'weekly', { title, content });
+    } catch (err) {
+      if (err instanceof Error && err.message === 'Invalid template') {
+        return res.status(400).json({ error: err.message });
+      }
+      throw err;
+    }
     const newsletter = await prisma.newsletter.create({ data: { title, content: html } });
     res.status(201).json(newsletter);
   } catch (err) {

--- a/server/src/services/newsletterGenerator.ts
+++ b/server/src/services/newsletterGenerator.ts
@@ -4,7 +4,13 @@ import Handlebars from 'handlebars';
 import PDFDocument from 'pdfkit';
 import { prisma } from '../prisma';
 
+const ALLOWED_TEMPLATES = ['weekly', 'monthly'] as const;
+export type NewsletterTemplate = (typeof ALLOWED_TEMPLATES)[number];
+
 export function renderTemplate(name: string, data: { title: string; content: string }): string {
+  if (!ALLOWED_TEMPLATES.includes(name as NewsletterTemplate)) {
+    throw new Error('Invalid template');
+  }
   const file = path.join(__dirname, `../templates/newsletters/${name}.hbs`);
   const tmpl = fs.readFileSync(file, 'utf-8');
   return Handlebars.compile(tmpl)(data);

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -207,4 +207,11 @@ describe('Newsletter API', () => {
     const docx = await request(app).get(`/api/newsletters/${id}/docx`);
     expect(docx.status).toBe(200);
   });
+
+  it('rejects invalid template name', async () => {
+    const res = await request(app)
+      .post('/api/newsletters')
+      .send({ title: 'Bad', content: 'X', template: 'oops' });
+    expect(res.status).toBe(400);
+  });
 });

--- a/server/tests/newsletterGenerator.test.ts
+++ b/server/tests/newsletterGenerator.test.ts
@@ -1,0 +1,17 @@
+import { renderTemplate } from '../src/services/newsletterGenerator';
+
+describe('newsletter template renderer', () => {
+  it('renders weekly and monthly templates', () => {
+    const weekly = renderTemplate('weekly', { title: 'T', content: 'C' });
+    const monthly = renderTemplate('monthly', { title: 'T', content: 'C' });
+    expect(weekly).toContain('T');
+    expect(monthly).toContain('T');
+  });
+
+  it('throws on invalid template name', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => renderTemplate('bad' as any, { title: 'T', content: 'C' })).toThrow(
+      'Invalid template',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- enforce allowed newsletter templates (`weekly`, `monthly`)
- reject invalid template names in the newsletter route
- add unit tests for template validation and API behaviour

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68465c37cd7c832d934ea67e69722f20