### PR TITLE
Update weekly planner test

### DIFF
--- a/client/tests/WeeklyPlanner.test.tsx
+++ b/client/tests/WeeklyPlanner.test.tsx
@@ -85,6 +85,7 @@ test('handles missing plan gracefully', () => {
   lessonPlanData = undefined;
   renderWithRouter(<WeeklyPlannerPage />);
   expect(screen.getByText('Auto Fill')).toBeInTheDocument();
+  expect(screen.getByTestId('no-plan-message')).toBeInTheDocument();
   // The component still renders the day grid even without plan data
   expect(screen.getByTestId('day-0')).toBeInTheDocument();
   // Check if it shows Monday label


### PR DESCRIPTION
## Summary
- verify the no plan message in WeeklyPlannerPage

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68465e155c10832dbdd4bd4409d3550f