### PR TITLE
Handle empty activity list in weekly plan generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ pnpm exec playwright install
 2. **Add Milestones**: Define major units or learning goals with target completion dates
 3. **Create Activities**: Populate milestones with specific lessons, assignments, and projects
 4. **Track Progress**: Mark activities as complete to automatically update progress bars
-5. **Plan Weekly**: Use the weekly planner (Phase 4) to schedule activities across your timetable
+5. **Plan Weekly**: Use the weekly planner (Phase 4) to schedule activities across your timetable. At least one activity must exist to auto-fill a plan
 6. **Communicate**: Generate parent newsletters from completed activities (Phase 4)
 
 ### Key Concepts

--- a/client/src/components/AutoFillButton.tsx
+++ b/client/src/components/AutoFillButton.tsx
@@ -1,5 +1,6 @@
 import { useGeneratePlan, LessonPlan } from '../api';
 import { toast } from 'sonner';
+import axios from 'axios';
 
 interface Props {
   weekStart: string;
@@ -11,7 +12,17 @@ export default function AutoFillButton({ weekStart, onGenerated }: Props) {
   const handleClick = () =>
     generate.mutate(weekStart, {
       onSuccess: (plan) => onGenerated?.(plan),
-      onError: () => toast.error('Failed to generate plan'),
+      onError: (err) => {
+        if (
+          axios.isAxiosError(err) &&
+          err.response?.status === 400 &&
+          typeof err.response.data?.error === 'string'
+        ) {
+          toast.error(err.response.data.error);
+        } else {
+          toast.error('Failed to generate plan');
+        }
+      },
     });
 
   return (

--- a/client/tests/WeeklyPlanner.test.tsx
+++ b/client/tests/WeeklyPlanner.test.tsx
@@ -81,6 +81,18 @@ test('displays toast on failure', () => {
   expect(toastErrorMock).toHaveBeenCalled();
 });
 
+test('shows server message on 400 failure', () => {
+  renderWithRouter(<WeeklyPlannerPage />);
+  fireEvent.click(screen.getByText('Auto Fill'));
+  const options = mutateMock.mock.calls[0][1];
+  if (options?.onError)
+    options.onError({
+      response: { status: 400, data: { error: 'No activities available' } },
+      isAxiosError: true,
+    });
+  expect(toastErrorMock).toHaveBeenCalledWith('No activities available');
+});
+
 test('handles missing plan gracefully', () => {
   lessonPlanData = undefined;
   renderWithRouter(<WeeklyPlannerPage />);

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -8,6 +8,9 @@ router.post('/generate', async (req, res, next) => {
   try {
     const { weekStart } = req.body as { weekStart: string };
     const scheduleData = await generateWeeklySchedule();
+    if (scheduleData.length === 0) {
+      return res.status(400).json({ error: 'No activities available' });
+    }
     const plan = await prisma.lessonPlan.create({
       data: {
         weekStart: new Date(weekStart),

--- a/server/tests/lessonPlans.test.ts
+++ b/server/tests/lessonPlans.test.ts
@@ -22,6 +22,7 @@ afterAll(async () => {
 
 describe('lesson plan routes', () => {
   let activityId: number;
+  let milestoneId: number;
   const weekStart = '2025-01-01T00:00:00.000Z';
 
   beforeAll(async () => {
@@ -29,8 +30,20 @@ describe('lesson plan routes', () => {
     const milestone = await prisma.milestone.create({
       data: { title: 'MP', subjectId: subject.id },
     });
+    milestoneId = milestone.id;
     const activity = await prisma.activity.create({
       data: { title: 'AP', milestoneId: milestone.id },
+    });
+    activityId = activity.id;
+  });
+
+  it('returns 400 when no activities exist', async () => {
+    await prisma.activity.deleteMany();
+    const res = await request(app).post('/api/lesson-plans/generate').send({ weekStart });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('No activities available');
+    const activity = await prisma.activity.create({
+      data: { title: 'AP', milestoneId },
     });
     activityId = activity.id;
   });


### PR DESCRIPTION
## Summary
- fail lesson plan generation if no activities exist
- surface server error details in AutoFillButton
- test empty schedule API behaviour
- test toast messaging for 400 responses
- clarify auto-fill requirements in README

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68466025cb3c832db88137876d6e428e