### PR TITLE
Add drag-drop scheduling test

### DIFF
--- a/client/tests/WeeklyPlanner.test.tsx
+++ b/client/tests/WeeklyPlanner.test.tsx
@@ -1,9 +1,11 @@
-import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { fireEvent, screen, waitFor, act } from '@testing-library/react';
 import WeeklyPlannerPage from '../src/pages/WeeklyPlannerPage';
 import { renderWithRouter } from '../src/test-utils';
-import type { LessonPlan } from '../src/api';
+import type { LessonPlan, Subject } from '../src/api';
 import { vi } from 'vitest';
 
+import type { DragEndEvent } from '@dnd-kit/core';
 const mutateMock = vi.fn();
 const refetchMock = vi.fn();
 // eslint-disable-next-line no-var, @typescript-eslint/no-explicit-any
@@ -18,11 +20,26 @@ vi.mock('sonner', () => {
 });
 
 const generateState = { mutate: mutateMock, isPending: false };
+let triggerDrop: (e: DragEndEvent) => void = () => {};
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual('@dnd-kit/core');
+  return {
+    ...actual,
+    DndContext: (props: {
+      children: React.ReactNode;
+      onDragEnd: (event: DragEndEvent) => void;
+    }) => {
+      triggerDrop = props.onDragEnd;
+      return <div>{props.children}</div>;
+    },
+  };
+});
 let lessonPlanData: LessonPlan | undefined = {
   id: 1,
   weekStart: '2025-01-01T00:00:00.000Z',
   schedule: [],
 };
+let subjects: Subject[] = [];
 
 vi.mock('../src/api', async () => {
   const actual = await vi.importActual('../src/api');
@@ -32,12 +49,13 @@ vi.mock('../src/api', async () => {
       data: lessonPlanData,
       refetch: refetchMock,
     }),
-    useSubjects: () => ({ data: [] }),
+    useSubjects: () => ({ data: subjects }),
     useGeneratePlan: () => generateState,
   };
 });
 
 beforeEach(() => {
+  subjects = [];
   lessonPlanData = {
     id: 1,
     weekStart: '2025-01-01T00:00:00.000Z',
@@ -50,6 +68,10 @@ beforeEach(() => {
 
 test('renders weekly planner layout', () => {
   renderWithRouter(<WeeklyPlannerPage />);
+  const draggable = screen.getByText('Act 1');
+  const dropZone = screen.getByTestId('day-0');
+  expect(draggable).toBeInTheDocument();
+  expect(dropZone).toBeInTheDocument();
   expect(screen.getByText('Auto Fill')).toBeInTheDocument();
   expect(screen.getByTestId('day-0')).toBeInTheDocument();
 });
@@ -90,4 +112,48 @@ test('handles missing plan gracefully', () => {
   expect(screen.getByTestId('day-0')).toBeInTheDocument();
   // Check if it shows Monday label
   expect(screen.getByText('Mon')).toBeInTheDocument();
+});
+
+test('saves schedule when dragging activity to a day', async () => {
+  subjects = [
+    {
+      id: 1,
+      name: 'Math',
+      milestones: [
+        {
+          id: 1,
+          title: 'M1',
+          subjectId: 1,
+          activities: [{ id: 1, title: 'Act 1', milestoneId: 1, completedAt: null }],
+        },
+      ],
+    },
+  ];
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  // @ts-expect-error mock fetch
+  global.fetch = fetchMock;
+
+  renderWithRouter(<WeeklyPlannerPage />);
+  const draggable = screen.getByText('Act 1');
+  const dropZone = screen.getByTestId('day-0');
+  expect(draggable).toBeInTheDocument();
+  expect(dropZone).toBeInTheDocument();
+  act(() => {
+    triggerDrop({
+      active: { id: 1 },
+      over: { data: { current: { day: 0 } } },
+    } as DragEndEvent);
+  });
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+  expect(fetchMock.mock.calls[0][0]).toBe('/api/lesson-plans/1');
+  expect(body.schedule).toEqual([
+    {
+      id: 0,
+      day: 0,
+      activityId: 1,
+      activity: { id: 1, title: 'Act 1', milestoneId: 1, completedAt: null },
+    },
+  ]);
 });


### PR DESCRIPTION
## Summary
- add drag-and-drop schedule test for WeeklyPlannerPage
- mock dnd-kit context to trigger drop events

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684661ac5a50832d8db190b3c9c2d0c5