### PR TITLE
Update droppable IDs for calendar grid

### DIFF
--- a/client/src/components/WeekCalendarGrid.tsx
+++ b/client/src/components/WeekCalendarGrid.tsx
@@ -13,7 +13,10 @@ export default function WeekCalendarGrid({ schedule, activities }: Props) {
       {days.map((d, idx) => {
         const item = schedule.find((s) => s.day === idx);
         const title = item ? activities[item.activityId]?.title : '';
-        const { isOver, setNodeRef } = useDroppable({ id: idx, data: { day: idx } });
+        const { isOver, setNodeRef } = useDroppable({
+          id: `day-${idx}`,
+          data: { day: idx },
+        });
         return (
           <div
             key={idx}


### PR DESCRIPTION
## Summary
- give `WeekCalendarGrid` droppable elements string IDs
- adjust drag-drop tests for new IDs
- verify activities appear in calendar after drag

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6846690604f4832d8f385a9281097b09