### PR TITLE
Fix weekStart date format for lesson plan APIs

### DIFF
--- a/client/src/__tests__/getWeekStartISO.test.ts
+++ b/client/src/__tests__/getWeekStartISO.test.ts
@@ -1,0 +1,6 @@
+import { getWeekStartISO } from '../api';
+
+test('normalizes week start to YYYY-MM-DD', () => {
+  const date = new Date('2025-06-09T12:05:40Z');
+  expect(getWeekStartISO(date)).toBe('2025-06-09');
+});

--- a/client/src/pages/WeeklyPlannerPage.tsx
+++ b/client/src/pages/WeeklyPlannerPage.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo } from 'react';
 import { DndContext, DragEndEvent } from '@dnd-kit/core';
-import { useLessonPlan, useSubjects, Activity } from '../api';
+import { useLessonPlan, useSubjects, Activity, getWeekStartISO } from '../api';
 import ActivitySuggestionList from '../components/ActivitySuggestionList';
 import WeekCalendarGrid from '../components/WeekCalendarGrid';
 import AutoFillButton from '../components/AutoFillButton';
 
 export default function WeeklyPlannerPage() {
-  const [weekStart, setWeekStart] = useState(() => new Date().toISOString());
+  const [weekStart, setWeekStart] = useState(() => getWeekStartISO(new Date()));
   const { data: plan, refetch } = useLessonPlan(weekStart);
   const subjects = useSubjects().data ?? [];
   const activities = useMemo(() => {
@@ -43,8 +43,8 @@ export default function WeeklyPlannerPage() {
       <div className="flex gap-2 items-center">
         <input
           type="date"
-          value={weekStart.split('T')[0]}
-          onChange={(e) => setWeekStart(new Date(e.target.value).toISOString())}
+          value={weekStart}
+          onChange={(e) => setWeekStart(getWeekStartISO(new Date(e.target.value)))}
           className="border p-1"
         />
         <AutoFillButton weekStart={weekStart} onGenerated={() => refetch()} />


### PR DESCRIPTION
## Summary
- ensure consistent weekStart format across API calls
- update WeeklyPlanner page to use new getWeekStartISO helper
- add unit test for getWeekStartISO

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6846cec7cbf0832d825b7e7c222c0227