### PR TITLE
Fix Vite proxy config and API base URL

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://127.0.0.1:3000

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
 });
 
 export const getWeekStartISO = (date: Date): string => {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,9 +1,19 @@
+// client/vite.config.ts
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   envPrefix: 'VITE_',
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:3000',
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- ensure React client API base URL reads from env var
- set Vite dev server proxy for `/api`
- add `.env` example for local dev

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68473e6b1194832db05d5c7c6400d09d