### PR TITLE
Add requirements traceability matrix and notes tasks

### DIFF
--- a/AGENTS-TODO-missing or underdeveloped features.md
+++ b/AGENTS-TODO-missing or underdeveloped features.md
@@ -10,26 +10,26 @@ Ensure weekly activity scheduling respects the teacher’s fixed timetable (e.g.
 
 ### ✅ Success Criteria:
 
-* Teacher can input/edit a visual timetable (e.g., Math at 9–10am, Prep 11:30–12, etc.)
-* Weekly planner only assigns activities to available subject-specific slots
-* Activities are not scheduled during prep, recess, or unassigned blocks
-* Teachers see a week view that reflects their real-world class structure
+- Teacher can input/edit a visual timetable (e.g., Math at 9–10am, Prep 11:30–12, etc.)
+- Weekly planner only assigns activities to available subject-specific slots
+- Activities are not scheduled during prep, recess, or unassigned blocks
+- Teachers see a week view that reflects their real-world class structure
 
 ### 📋 Tasks:
 
 **\[Frontend]**
 
-* `CreateTimetableUIComponent`: Build an interactive weekly grid editor (e.g., 30-min blocks 8:30–3:00) allowing teachers to mark subject slots, breaks, and prep time.
-* `DisplayTimetableInPlanner`: Show the defined timetable overlay in the weekly planner view (e.g., greyed out blocks for prep, labeled blocks for each subject).
+- `CreateTimetableUIComponent`: Build an interactive weekly grid editor (e.g., 30-min blocks 8:30–3:00) allowing teachers to mark subject slots, breaks, and prep time.
+- `DisplayTimetableInPlanner`: Show the defined timetable overlay in the weekly planner view (e.g., greyed out blocks for prep, labeled blocks for each subject).
 
 **\[Backend]**
 
-* `TeacherTimetableModel`: Create DB model for teacher schedules: `day`, `startTime`, `endTime`, `subject`.
-* `UpdateWeeklyPlanAlgorithm`: Modify the `generateWeeklySchedule` function to:
+- `TeacherTimetableModel`: Create DB model for teacher schedules: `day`, `startTime`, `endTime`, `subject`.
+- `UpdateWeeklyPlanAlgorithm`: Modify the `generateWeeklySchedule` function to:
 
-  * Place activities only in valid subject blocks
-  * Leave prep and breaks unscheduled
-  * Warn if not enough slots are available to schedule all desired activities
+  - Place activities only in valid subject blocks
+  - Leave prep and breaks unscheduled
+  - Warn if not enough slots are available to schedule all desired activities
 
 ---
 
@@ -41,29 +41,29 @@ Automatically generate detailed daily lesson plans from the weekly schedule, inc
 
 ### ✅ Success Criteria:
 
-* Clicking on a day in the weekly plan shows a full daily schedule with all blocks
-* Teacher can drag/drop activities and manually fill in missing blocks
-* Printable daily plan includes:
+- Clicking on a day in the weekly plan shows a full daily schedule with all blocks
+- Teacher can drag/drop activities and manually fill in missing blocks
+- Printable daily plan includes:
 
-  * Time slots
-  * “Daily why” objective
-  * Activity instructions
-  * Materials
-  * Assessment notes
+  - Time slots
+  - “Daily why” objective
+  - Activity instructions
+  - Materials
+  - Assessment notes
 
 ### 📋 Tasks:
 
 **\[Frontend]**
 
-* `DailyPlanEditor`: Visual editor for structuring a day's lessons, tied to the timetable
-* `PrintableDailyPlanView`: PDF export of the daily plan with proper formatting
-* `AutoPopulateFromWeeklyPlan`: Fill daily slots with activities based on weekly plan + timetable
+- `DailyPlanEditor`: Visual editor for structuring a day's lessons, tied to the timetable
+- `PrintableDailyPlanView`: PDF export of the daily plan with proper formatting
+- `AutoPopulateFromWeeklyPlan`: Fill daily slots with activities based on weekly plan + timetable
 
 **\[Backend]**
 
-* `DailyPlanModel`: Store per-day structured plans linked to weekly plan and activity list
-* `GenerateDefaultDailyPlanFromWeekly`: API endpoint to generate a stub daily plan with time slots, placeholder notes
-* `LinkEmergencySubPlanToDailyPlan`: Emergency plan uses latest saved daily plan, with optional override
+- `DailyPlanModel`: Store per-day structured plans linked to weekly plan and activity list
+- `GenerateDefaultDailyPlanFromWeekly`: API endpoint to generate a stub daily plan with time slots, placeholder notes
+- `LinkEmergencySubPlanToDailyPlan`: Emergency plan uses latest saved daily plan, with optional override
 
 ---
 
@@ -75,32 +75,33 @@ Generate, preview, and send a newsletter using the data already in the system—
 
 ### ✅ Success Criteria:
 
-* Clicking "Generate Newsletter" for a date range pre-fills newsletter draft
-* Draft includes completed activities with summaries, milestones met, and class photos
-* Teacher can edit and save draft
-* Can export to PDF and/or send to stored list of parent emails
+- Clicking "Generate Newsletter" for a date range pre-fills newsletter draft
+- Draft includes completed activities with summaries, milestones met, and class photos
+- Teacher can edit and save draft
+- Can export to PDF and/or send to stored list of parent emails
 
 ### 📋 Tasks:
 
 **\[Backend]**
 
-* `NewsletterAutoDraftService`: Generate newsletter content based on:
+- `NewsletterAutoDraftService`: Generate newsletter content based on:
 
-  * Completed activities
-  * Progress updates (e.g., milestones hit)
-  * Upcoming scheduled items
-* `ParentContactModel`: Store parent email list per class
-* `SendNewsletterAPI`: Endpoint to email PDF newsletter using SendGrid (or other provider)
+  - Completed activities
+  - Progress updates (e.g., milestones hit)
+  - Upcoming scheduled items
+
+- `ParentContactModel`: Store parent email list per class
+- `SendNewsletterAPI`: Endpoint to email PDF newsletter using SendGrid (or other provider)
 
 **\[Frontend]**
 
-* `NewsletterGenerationUI`: Interface to select week range, generate draft, and preview auto-filled content
-* `EditNewsletterWithSuggestions`: Rich text editor with pre-filled content blocks for each section
-* `ExportAndSendOptions`: UI buttons to export PDF and to email all parent contacts
+- `NewsletterGenerationUI`: Interface to select week range, generate draft, and preview auto-filled content
+- `EditNewsletterWithSuggestions`: Rich text editor with pre-filled content blocks for each section
+- `ExportAndSendOptions`: UI buttons to export PDF and to email all parent contacts
 
 **\[Templates]**
 
-* `weekly_newsletter.hbs`: Improve template to support dynamic sections (e.g., “What we did”, “Photos”, “Coming up”)
+- `weekly_newsletter.hbs`: Improve template to support dynamic sections (e.g., “What we did”, “Photos”, “Coming up”)
 
 ---
 
@@ -112,24 +113,24 @@ Ensure the teacher has a clear checklist of all materials needed for the week, a
 
 ### ✅ Success Criteria:
 
-* Materials list auto-generated from all activities in the weekly/daily plans
-* Teacher sees interactive checklist UI with checkboxes
-* Printable resources flagged in each activity are downloadable as a ZIP file
-* Teacher can preview and print any document from the week’s plan
+- Materials list auto-generated from all activities in the weekly/daily plans
+- Teacher sees interactive checklist UI with checkboxes
+- Printable resources flagged in each activity are downloadable as a ZIP file
+- Teacher can preview and print any document from the week’s plan
 
 ### 📋 Tasks:
 
 **\[Backend]**
 
-* `AutoExtractMaterialsFromActivityNotes`: Improve regex/NLP to extract material names even from freeform text
-* `BuildWeeklyMaterialListService`: Given weekly plan, return materials checklist grouped by day/activity
-* `ZipPrintableResourcesEndpoint`: Package all activity-linked printable files for a week into one downloadable ZIP
+- `AutoExtractMaterialsFromActivityNotes`: Improve regex/NLP to extract material names even from freeform text
+- `BuildWeeklyMaterialListService`: Given weekly plan, return materials checklist grouped by day/activity
+- `ZipPrintableResourcesEndpoint`: Package all activity-linked printable files for a week into one downloadable ZIP
 
 **\[Frontend]**
 
-* `WeeklyMaterialsChecklistUI`: Show grouped list of needed materials with checkboxes and links to relevant activities
-* `DownloadAllPrintablesButton`: Allows teacher to fetch all printable files for the week in one ZIP
-* `FlagMissingPrintables`: Alert if scheduled activities have missing resources
+- `WeeklyMaterialsChecklistUI`: Show grouped list of needed materials with checkboxes and links to relevant activities
+- `DownloadAllPrintablesButton`: Allows teacher to fetch all printable files for the week in one ZIP
+- `FlagMissingPrintables`: Alert if scheduled activities have missing resources
 
 ---
 
@@ -141,24 +142,24 @@ Unify the system flow so that weekly planning, daily execution, materials prep, 
 
 ### ✅ Success Criteria:
 
-* Progress alerts influence planning suggestions (e.g., if behind on Math, planner recommends more Math)
-* Material checklist updates when plan is adjusted
-* Newsletter pulls directly from progress and plan data
-* Notifications surface clearly in UI and link to actionable next steps
+- Progress alerts influence planning suggestions (e.g., if behind on Math, planner recommends more Math)
+- Material checklist updates when plan is adjusted
+- Newsletter pulls directly from progress and plan data
+- Notifications surface clearly in UI and link to actionable next steps
 
 ### 📋 Tasks:
 
 **\[Backend]**
 
-* `PlanningIntegrationWithProgress`: Update planning algorithm to consider milestone urgency when selecting activities
-* `ReactiveMaterialListUpdate`: Regenerate material list whenever weekly/daily plan is updated
-* `ProgressInfluencesNewsletterContent`: Include milestone completion summaries automatically in newsletter drafts
+- `PlanningIntegrationWithProgress`: Update planning algorithm to consider milestone urgency when selecting activities
+- `ReactiveMaterialListUpdate`: Regenerate material list whenever weekly/daily plan is updated
+- `ProgressInfluencesNewsletterContent`: Include milestone completion summaries automatically in newsletter drafts
 
 **\[Frontend]**
 
-* `PlannerNotificationBanner`: Surface progress alerts in weekly planner with one-click “Insert Recovery Activity”
-* `MaterialsReminderPrompt`: After planning, prompt user to review/print materials
-* `AutoNewsletterPrompt`: On Fridays, offer to generate a newsletter from weekly summary
+- `PlannerNotificationBanner`: Surface progress alerts in weekly planner with one-click “Insert Recovery Activity”
+- `MaterialsReminderPrompt`: After planning, prompt user to review/print materials
+- `AutoNewsletterPrompt`: On Fridays, offer to generate a newsletter from weekly summary
 
 ---
 
@@ -170,32 +171,32 @@ Ensure features marked “done” are actually useful and production-ready (e.g.
 
 ### ✅ Success Criteria:
 
-* Weekly planner generates multiple activities per day with subject balancing
-* Newsletter generator includes actual content generation logic
-* Emergency plan reflects actual daily plan content, not placeholders
-* Progress alerts actually reach the teacher via visible notifications or emails
+- Weekly planner generates multiple activities per day with subject balancing
+- Newsletter generator includes actual content generation logic
+- Emergency plan reflects actual daily plan content, not placeholders
+- Progress alerts actually reach the teacher via visible notifications or emails
 
 ### 📋 Tasks:
 
 **\[Weekly Planner]**
 
-* `MultiActivityPerDayPlannerLogic`: Schedule multiple blocks per day per subject, based on timetable
-* `SubjectBalancingRules`: Avoid front-loading or omitting subjects
+- `MultiActivityPerDayPlannerLogic`: Schedule multiple blocks per day per subject, based on timetable
+- `SubjectBalancingRules`: Avoid front-loading or omitting subjects
 
 **\[Newsletter]**
 
-* `ContentTemplateBlocks`: Add weekly highlights, class photos, and learning goals to draft generation
-* `EmailServiceIntegration`: Set up SendGrid or Mailgun API for email delivery
+- `ContentTemplateBlocks`: Add weekly highlights, class photos, and learning goals to draft generation
+- `EmailServiceIntegration`: Set up SendGrid or Mailgun API for email delivery
 
 **\[Emergency Plan]**
 
-* `PullRealDailyPlan`: Replace hardcoded sample with latest saved daily plan
-* `IncludeContactAndProcedureFields`: Allow teacher to pre-fill school routines, contacts, etc.
+- `PullRealDailyPlan`: Replace hardcoded sample with latest saved daily plan
+- `IncludeContactAndProcedureFields`: Allow teacher to pre-fill school routines, contacts, etc.
 
 **\[Alerts]**
 
-* `NotificationCenterComponent`: Build frontend UI to show all triggered alerts
-* `EmailFallbackForIn-App Alerts`: If not read in-app in 48h, alert is emailed
+- `NotificationCenterComponent`: Build frontend UI to show all triggered alerts
+- `EmailFallbackForIn-App Alerts`: If not read in-app in 48h, alert is emailed
 
 ---
 
@@ -207,15 +208,15 @@ Ensure every line item in the Implementation Plan is represented by an implement
 
 ### ✅ Success Criteria:
 
-* Every outcome in the Implementation Plan is either “Implemented,” “Planned,” or “Deferred (v2)”
-* New tasks are created for anything omitted
-* All key objectives are traceable to one or more AGENT tasks
+- Every outcome in the Implementation Plan is either “Implemented,” “Planned,” or “Deferred (v2)”
+- New tasks are created for anything omitted
+- All key objectives are traceable to one or more AGENT tasks
 
 ### 📋 Tasks:
 
-* `CreateRequirementsTraceabilityMatrix`: List all Implementation Plan goals and map to current tasks/features
-* `FlagMissingFeatures`: Identify any plan goal not implemented or assigned a task
-* `CreateAGENTTasksFromTraceabilityGaps`: For each missing item, write an explicit task with success criteria
+- `CreateRequirementsTraceabilityMatrix`: List all Implementation Plan goals and map to current tasks/features
+- `FlagMissingFeatures`: Identify any plan goal not implemented or assigned a task
+- `CreateAGENTTasksFromTraceabilityGaps`: For each missing item, write an explicit task with success criteria
 
 ---
 
@@ -227,24 +228,50 @@ Make the tool feel like an integrated assistant, not a disconnected set of tools
 
 ### ✅ Success Criteria:
 
-* Main dashboard shows teacher’s week at a glance (schedule, materials, newsletter status)
-* Common actions are available contextually (e.g., after planning, prompt for newsletter or printables)
-* Workflow is intuitive and clearly sequenced from week generation → resource prep → communication
+- Main dashboard shows teacher’s week at a glance (schedule, materials, newsletter status)
+- Common actions are available contextually (e.g., after planning, prompt for newsletter or printables)
+- Workflow is intuitive and clearly sequenced from week generation → resource prep → communication
 
 ### 📋 Tasks:
 
 **\[Frontend]**
 
-* `UnifiedWeekViewComponent`: Combine planner, material checklist, and newsletter generator into one dashboard
-* `PostPlanningActionPrompts`: After generating a plan, automatically prompt to generate materials and newsletter
-* `TeacherOnboardingFlow`: Add onboarding/tutorial overlay for new users to guide through workflow
+- `UnifiedWeekViewComponent`: Combine planner, material checklist, and newsletter generator into one dashboard
+- `PostPlanningActionPrompts`: After generating a plan, automatically prompt to generate materials and newsletter
+- `TeacherOnboardingFlow`: Add onboarding/tutorial overlay for new users to guide through workflow
 
 ---
 
+## 📝 9. Notes & Reflection Management
+
+### ❗Goal:
+
+Capture private reflections and public comments linked to activities and daily plans.
+
+### ✅ Success Criteria:
+
+- Teacher can add/edit notes for activities and daily plans
+- Public notes can be included in newsletters
+- Notes searchable by date or subject
+- Data stored via CRUD API
+
+### 📋 Tasks:
+
+**[Backend]**
+
+- `CreateNotesModel`: Add `Note` model linked to activities and days
+- `NotesAPIRoutes`: CRUD endpoints `/api/notes`
+- `IncludeNotesInNewsletter`: Pull public notes into newsletter drafts
+
+**[Frontend]**
+
+- `DailyNotesEditor`: Form for notes within DailyPlanPage
+- `NotesSearchView`: Filter notes by date or subject
+
 Would you like me to also:
 
-* Break these into prioritized tiers (e.g., must-have vs polish)?
-* Generate GitHub issues in Markdown format?
-* Generate a JSON schema that a coding agent could use to auto-assign tasks?
+- Break these into prioritized tiers (e.g., must-have vs polish)?
+- Generate GitHub issues in Markdown format?
+- Generate a JSON schema that a coding agent could use to auto-assign tasks?
 
 Let me know how you’d like to proceed.

--- a/docs/impl_plan.txt
+++ b/docs/impl_plan.txt
@@ -1,0 +1,892 @@
+Implementation Plan: Elementary Teacher
+Curriculum Planning System
+Introduction & Overview
+This implementation plan outlines a standalone software system to help a single elementary school teacher
+in Canada manage yearly curriculum planning and delivery. The system’s goal is to streamline all phases of
+teaching: long-term curriculum mapping, weekly lesson planning, resource preparation, progress tracking,
+parent communication, and emergency substitutions. It will provide an intuitive interface for non-technical
+users, optimized for desktop and tablet use. Key features include: a subject-wise curriculum directory,
+weekly planning workflows with activity suggestions, automated resource lists, dynamic progress tracking
+with adaptive scheduling, parent newsletter generation, one-click emergency sub plans, and robust notekeeping for teacher reflections and parent-facing comments. By consolidating these functions in one tool,
+the system will serve as a “digital teaching assistant,” reducing administrative overhead and allowing the
+teacher to focus on instruction 1 2 . The plan below details the system architecture, module designs, UI
+components, and workflow for each feature.
+
+System Architecture & Tech Stack
+
+Figure: System architecture illustrating the user interface, application logic, and data storage components.
+To ensure the system is user-friendly and accessible on multiple devices, a web-based architecture is
+recommended. The core components are:
+• User Interface (UI): A responsive web application (or packaged desktop app) that runs on desktop
+browsers and tablets. The UI will be built with a modern JavaScript framework such as React.js (for a
+dynamic, responsive experience) 3 . This ensures a rich interface that can adapt to different screen
+sizes and touch input. HTML5 and CSS3 (with a UI toolkit for consistency) will be used for layout,
+providing large, clear buttons and text for non-technical users. The UI should follow accessible
+
+1
+
+design practices and minimal complexity, focusing on workflows like planning and checking off
+tasks.
+• Application Logic: A local backend that handles data processing, scheduling algorithms, and file
+generation. For a straightforward standalone setup, this can be a lightweight Node.js server
+running locally (packaged with the app) 4 . Node.js offers good integration with front-end
+JavaScript and can generate PDF/DOCX outputs on demand. Alternatively, a desktop framework like
+Electron could bundle the front-end and backend together, enabling offline use. The application
+logic is structured into modules (Curriculum Planning, Scheduling Engine, Resource Manager,
+Tracking & Analytics, Communication Generator, etc.) for modularity. This modular design makes
+future scaling easier – e.g. replacing the local backend with a cloud server for multi-teacher
+deployments, or adding new modules like admin oversight without impacting others.
+• Data Storage: A local database stores all teacher data – subjects, milestones, activities, schedules,
+notes, etc. An embedded relational database like SQLite is ideal for a single-user, local system (zero
+configuration, file-based storage). This database will persist data on the teacher’s machine and can
+be synced or backed up manually if needed. Should the system scale to multiple users in future,
+migrating to a server-hosted DB (e.g. PostgreSQL or MySQL) would be straightforward 5 . The data
+schema will include tables for Subjects, Milestones, Activities, Calendar (scheduled plans), Resources,
+and Notes, with relationships linking them (e.g. Milestones belong to Subjects; Activities link to
+Milestones; etc.).
+• File Storage: The system will store any uploaded files (like lesson resources or photos) in a
+designated local directory. The application logic will manage links to these files in the database. For
+simplicity, files (worksheets, images, etc.) can be stored on the local filesystem (or in the app’s data
+directory) and referenced by path. This keeps the app lightweight; for future cloud-based versions,
+this can be abstracted to cloud storage.
+• Export/Report Generation: A sub-component of the backend handles exporting content to PDF or
+DOCX. This may utilize libraries (e.g. PDFKit or Puppeteer for PDF, and a DOCX library) to generate
+print-ready documents for lesson plans and newsletters. This component will pull data from the
+database (and relevant files) to compile documents on the fly.
+The above architecture ensures modularity and scalability. Each major feature corresponds to a module in
+the application logic, which interacts with the others via defined interfaces. This means new features (or
+multi-user support) can be added without rewriting the entire system. For example, to support multiple
+teachers or admin oversight later, one could introduce user accounts and a cloud-sync module while
+reusing the planning and tracking modules. The tech stack (React front-end, Node.js backend, SQLite
+database) is chosen for simplicity and broad developer support, but other equivalent stacks (e.g. an Angular
+or Vue front-end with a Python/Flask or .NET Core backend) could also fulfill the requirements 3 4 . The
+priority is that the stack enables a smooth, minimal-click user experience and offline capability (since a
+teacher may need access even without internet).
+User Interface Design Considerations: The UI will be designed for a teacher with minimal tech training.
+That means a clean layout with clear navigation (likely a sidebar or top menu for major sections:
+Curriculum, Weekly Plan, Resources, Progress, Communication, Notes). Icons and labels will be used for
+recognizability. For example, a calendar icon for scheduling, a checklist icon for resources, etc. The interface
+
+2
+
+should minimize typing and allow drag-and-drop where possible (e.g. dragging an activity into a weekly
+calendar). Consistency is key – the user should always know where they are and how to get back. By
+centralizing all planning tasks in one interface, we reduce the need for separate spreadsheets, documents,
+and calendars 6 7 . Additionally, the design will incorporate quick tips or onboarding prompts to guide
+first-time users through setting up their subjects and schedule, ensuring a low learning curve.
+
+Subject Directory and Curriculum Planning
+This module allows the teacher to map out the year’s curriculum by subject, breaking it down into
+milestones and activities. It essentially functions as a curriculum mapping tool tailored to a single
+classroom. Key capabilities and design elements include:
+• Subjects & Milestones Data Model: The teacher can create a directory of subjects (e.g. Math,
+English, Science, Social Studies, etc.). Under each subject, the teacher defines curriculum
+milestones – major goals or units (for example, a Science unit on “Weather and Climate” or a Math
+milestone “Mastering Multiplication 1-12”). Each milestone record holds a title, description/objective,
+estimated total time required (in hours or class periods), and a target completion date. Storing these in
+a structured way lets the system later track coverage and pacing 8 . The estimated time and target
+date will be used by the scheduling engine to pace the lessons. For instance, a milestone with 10
+hours and a target date 8 weeks away signals the system to schedule roughly an hour/week for it.
+• Activities Linked to Milestones: Teachers can associate multiple activities with each milestone. An
+activity is a specific lesson or learning task (e.g. an experiment, a worksheet, a group project, a field
+trip). Within the system, each activity entry includes fields like: duration (estimated minutes or class
+periods), required resources (materials or files, detailed below), and optionally activity type or
+teaching style (lecture, hands-on, etc.). These activities effectively form a library of tasks to achieve
+the milestone. By linking them to milestones, the teacher maintains alignment between daily lessons
+and larger curriculum goals 8 . Activities can be reordered within a milestone to suggest a
+sequence, or flagged as “core” vs “extension” to indicate priority.
+• User Interface – Curriculum Planner: A dedicated screen will allow managing subjects, milestones,
+and activities in an organized way. For example, the UI might have a left sidebar listing all subjects.
+Clicking a subject shows a list of its milestones (perhaps as cards or a collapsible outline). Each
+milestone entry displays its title, target date, and a progress indicator (e.g. 0% initially). Within a
+milestone card, its linked activities are listed (with maybe icons indicating duration or type). The
+teacher can add/edit milestones and activities via simple forms (invoked by an “Add Milestone” or
+“Add Activity” button). Milestones can have meta-data like curriculum standards or skills, but those
+can be optional for simplicity (the system could allow the teacher to tag a milestone with official
+curriculum codes if desired for reference). The UI should make it easy to drag-and-drop activities
+between milestones or reorder them, supporting the teacher in organizing content logically.
+• Linking and References: The system encourages the teacher to break big goals into concrete
+activities. All this data is stored centrally so it can be reused and analyzed later. This means, over
+time, the teacher builds a reusable curriculum repository – milestones and activities can carry over
+to the next year, refined with notes on what worked 9 . The interface will offer an option to copy an
+entire subject’s plan from a previous year or import milestones from an existing template, to save
+time in future planning.
+
+3
+
+• Estimated Time vs Calendar Integration: As milestones have estimated hours and target dates,
+the system will internally calculate a suggested pacing (hours per week needed). This provides a
+baseline for the Weekly Planning module to generate recommendations. The teacher can adjust
+target dates anytime; the system will warn if the plan is currently ahead or behind schedule for that
+milestone (based on activities completed vs time remaining).
+• Example Use: At the start of the school year (or term), the teacher uses this module to outline each
+subject. For instance, for Math they enter milestones like “Unit 1: Numbers and Place Value
+(September)”, “Unit 2: Addition and Subtraction (October)”, each with key outcomes and hours. They
+then list activities for Unit 1 (e.g. “Place value chart activity – 30min”, “Worksheet on tens and ones –
+15min”, “Group game on number forms – 20min”). This setup readies the system for generating
+weekly lesson suggestions.
+The design of this module emphasizes clarity and alignment: the teacher always has a clear view of what
+needs to be taught and by when. By structuring curriculum content digitally, the system provides a “central
+hub” of lesson plans and resources 10 . This not only reduces the chance of forgetting a planned activity,
+but also simplifies updating and reusing content year to year (similar to how curriculum management tools
+let educators build a growing repository of lessons 9 ).
+
+Weekly Planning Workflow
+This is the heart of the system’s day-to-day usage: each week, the software helps the teacher plan specific
+lessons from the curriculum. The workflow is designed to be proactive – the system will suggest activities
+based on the curriculum pacing and the teacher’s preferences, and then help schedule them into the
+teacher’s timetable.
+1. Calendar & Timetable Setup: First, the teacher inputs their timetable or calendar into the system (likely
+done once at the start, with adjustments as needed). This includes the class schedule on each weekday –
+e.g. “Math: Daily 9:00–9:45, English: Daily 10:00–10:45, Science: Tue/Thu 11:00–12:00,” etc. The interface for
+this could be a simple week schedule grid where the teacher labels blocks for each subject. The system will
+use this template to know how many slots are available for each subject weekly. It also allows entering nonteaching times, holidays or special days (so the planning avoids those). This replicates the functionality of
+setting up a class schedule as seen in many planners (e.g. weekly or cycle schedules, alternate days for
+certain subjects) 11 .
+2. Automated Activity Suggestions: At the start of a week (or when planning a future week), the teacher
+opens the Weekly Planner screen. Here, the system presents a “menu” of suggested activities for the
+upcoming week, tailored to meet curriculum milestones. The suggestion algorithm considers several
+factors: (a) Curriculum pacing – which milestones are approaching their target date or currently in progress,
+and how many hours remain, (b) Subjects frequency – ensuring each subject gets appropriate attention (e.g.
+if Science is only twice a week, it might suggest a Science activity each session), and (c) Variety and teacher
+preferences – possibly rotating through different activity types to keep students engaged 12 . For example, if
+a Math unit is behind schedule, the system will prioritize pending Math activities in the suggestions. It
+might say “Suggested this week: Math – do 2 activities from Unit 2 (Multiplication) to stay on track; Science
+
+4
+
+– 1 activity from Weather unit (target date nearing); English – continue next reading comprehension
+activity,” etc. Each suggestion will reference the milestone and activity name.
+• Filtering by Style, Skills, Resources: The teacher can refine the suggestions using filters. Perhaps the UI
+offers checkboxes or a dropdown to filter activities by teaching style (e.g. “Hands-on” vs “Lecture” vs
+“Collaborative”), by skill focus (e.g. “critical thinking”, “memorization”), or by required resources (so the
+teacher can avoid suggesting an activity if, say, the science lab is not available this week). This helps
+tailor the weekly plan to practical considerations and teaching style. For instance, a teacher might
+filter to see only “group activities” if they want a collaborative session on Friday. Providing these
+filters empowers teachers to select activities that best fit their class’s needs and the available
+resources, aligning with best practices of catering to diverse learning styles 12 .
+• User-Friendly Suggestions Display: The suggested activities could be listed in a panel, grouped by
+subject or day. Each suggestion entry might show the activity name, its linked milestone, estimated
+duration, and icons for style or resources (for quick scanning). If the teacher is unsure about an
+activity, they can click it to view details (the description, objectives, needed materials). This helps in
+decision-making before adding it to the plan.
+3. Activity Selection and Customization: From the suggestions (and possibly the full activity library), the
+teacher selects which activities to include for the week. The UI supports either drag-and-drop of an activity
+into a weekly calendar or clicking “Add to Week” and specifying a day/period. The system automatically
+knows the class times (from timetable) and can place the activity into the correct slot (e.g. if teacher picks a
+Science activity for this week, it slots into the Science periods on, say, Tuesday). The teacher can override the
+placement (drag it to Thursday instead, for example). They can also adjust the order of activities if multiple
+are suggested for the same subject.
+• The Weekly Planner interface likely shows a week view calendar (Mon–Fri) with each day column
+broken into the pre-defined class periods. Unplanned periods show as blank or free. As the teacher
+adds activities, they appear in the calendar blocks. This gives a visual confirmation that each day is
+fully planned (or where gaps remain).
+• Teachers can also introduce new activities on the fly or tweaks. For instance, if none of the
+suggestions suit a need, the teacher might create a quick custom activity (e.g. a review game) and
+slot it in. The system will allow adding an ad-hoc activity not tied to a milestone (marking it as
+supplemental). This flexibility is important so that teachers don’t feel constrained by the suggestions.
+4. Auto-Generation of Detailed Daily Plans: Once the teacher finalizes the week’s selected activities and
+their scheduled slots, the system will generate detailed day plans for each day. Each day plan will list the
+schedule (times and subjects) and under each subject, the specific activity with its details. For example, the
+Monday plan might read: 9:00 Math – Activity: “Multiplication Game” (20 min, uses flashcards); 10:00 English –
+Activity: “Read Chapter 3 and Discuss” (30 min, no special materials); 11:00 Social Studies – Activity: “Map Skills
+Worksheet” (worksheet attached). The generation of these day plans is automatic from the weekly calendar
+input, ensuring that the teacher has a coherent script/outline to follow each day. The teacher can click on
+any activity in the day plan to see full instructions or attached files (e.g. open the worksheet PDF).
+• The day plans are aligned to the teacher’s actual timetable times. If a class is only 30 minutes, the
+system will flag if an activity’s duration exceeds that, prompting the teacher to adjust (split the
+
+5
+
+activity or extend to next day). This prevents scheduling mishaps. Tools like Planbook allow teachers
+to easily bump or move lessons to another day if they don’t fit or if something changes 13 ; our
+system will similarly allow adjusting the schedule by dragging or with a “bump” button (which could
+move an unfinished activity to the next class slot automatically).
+5. Example Weekly Workflow: On Friday afternoon, the teacher opens the Weekly Planner for the next
+week. The system highlights that in Math, the class is a bit behind (perhaps the milestone target is
+approaching), so it suggests two Math activities (e.g. “Multiplication Game” and “Quiz on Times Tables”) to
+cover needed ground. It also knows a new Science unit was scheduled to start, so it suggests “Intro to
+Weather video” for Science. The teacher reviews these, maybe filters out activities that need the projector
+because it’s broken (using the resource filter), and swaps in an alternative. They drag the activities onto
+Monday and Wednesday for Math, Tuesday for Science, etc. The system fills the other regular slots with
+continued routines (perhaps an English reading activity was already planned from a previous week if
+unfinished, etc.). Once satisfied, the teacher saves the week plan. The software then provides printable
+daily plans for Monday through Friday, which the teacher can print or view on the tablet each morning.
+This workflow greatly reduces the manual effort of writing out plans for each day – it’s largely automated
+based on the selected activities 14 .
+UI Considerations: The Weekly Planner UI must balance automation with control. It will likely consist of two
+main areas: a suggestion panel (with lists or cards of activities, possibly segmented by subject) and a
+weekly calendar view. The teacher should be able to toggle between a week overview and a single-day
+detailed view easily. Visual cues (like color-coding by subject) help scan the plan at a glance. For example, all
+Math activities might appear in blue blocks, English in green, etc., matching perhaps the subject’s color as
+set by the teacher. This matches common teacher planner layouts where each subject has a color in a
+timetable. Additionally, we can include a “pacing guide” indicator – e.g. a small progress bar or icon on each
+milestone suggestion indicating how much of that milestone is completed vs time elapsed in the term, so
+the teacher understands why the system is suggesting it (like a red alert icon if behind schedule, or green if
+ahead). This increases transparency of the AI planning assistant.
+Integration with Calendar: Optionally, the system could integrate or sync with external calendars (like
+adding events to Google Calendar) so that the teacher’s schedule with planned activities can be viewed on
+their personal calendar. However, given this is a standalone tool and to avoid complexity, this might be a
+future enhancement. For now, exporting the weekly plan as a PDF or DOCX (discussed later) would allow
+sharing with school administrators or printing for quick reference, achieving a similar goal 15 .
+In summary, the Weekly Planning module provides a smart lesson planning assistant. By referencing the
+curriculum map and applying teacher input, it ensures the teacher always has appropriate lessons lined up,
+avoiding last-minute scrambles. This automation yields efficiency and consistency – research indicates that
+such planning software boosts teachers’ efficiency and time management by automating the
+organization of lessons and materials 14 . Moreover, the ability to adapt suggestions by style/resources
+keeps the plans flexible and tailored to the classroom’s immediate context, which is a significant
+pedagogical advantage.
+
+Resource and Preparation Management
+A critical part of weekly teaching prep is gathering materials. This module of the system focuses on
+automatically compiling all resources needed for the upcoming lessons, saving the teacher time and
+
+6
+
+ensuring nothing is overlooked. It produces both a checklist of physical materials and a package of digital/
+printable files each week.
+• Resource Database: Each activity in the system can have associated resources. When creating or
+editing an activity (in the Curriculum Planner or Weekly Planner), the teacher can specify resources
+needed. These might include physical materials (e.g. “scissors, construction paper, glue”), tools/
+technology (“projector, iPads”), and printable documents (worksheets, handouts, quizzes in PDF/
+DOCX format). The software will allow uploading files to attach to activities (for example, attaching
+the PDF of a worksheet or a link to an online resource). These file attachments are stored in the
+system’s file storage and linked to the activity record 16 . By building a rich library of resources tied
+to each activity, the system can later fetch exactly what’s needed for any set of activities.
+• Weekly Resource Checklist: Once the teacher finalizes a weekly plan (or at any time views the
+week’s plan), the system generates a consolidated list of materials required for all selected
+activities of that week. This list is presented in a “Weekly Prep” view. For convenience, it can be
+grouped by day or by category. For example, it might list: Monday: projector, markers; Tuesday: (no
+special materials); Wednesday: lab materials – vinegar, baking soda; etc., or it might list Materials to
+prepare this week: then a bullet list combining all days (with day labels if needed). Grouping by
+category could also be useful: e.g. Printables: “Worksheet1.pdf, Worksheet2.pdf”, Supplies: “markers,
+glue, scissors”, Tech: “projector, math software”. The teacher can use this as a checklist, ticking off
+items as they gather them on Friday or Monday morning. The aim is to eliminate the scenario of
+discovering mid-class that a needed material is missing. This approach reflects the centralized
+organization benefit of planning software – all teaching materials are accounted for in one place 10 .
+• Printable Material Packaging: The system will also automatically compile all printable resources
+needed for the week. If, for instance, three PDFs were attached to various activities scheduled this
+week, the software can bundle them. This could be done by zipping them into one file for download,
+or more elegantly, merging PDFs into a single “weekly packet”. The teacher can then print this packet
+in one go, instead of opening and printing each file separately. For example, if Monday’s math
+activity has a worksheet and Thursday’s English has a quiz handout, the system’s Prep view will have
+a “Download Printables” button. Clicking it might provide a single PDF containing “Worksheet – Math
+Monday” followed by the actual worksheet pages, then “Quiz – English Thursday” and those pages,
+etc., in order. Alternatively, it just gives a zip with each file named clearly. The packaging ensures no
+file is missed and saves effort. It’s akin to having a mini resource library for the week’s lessons
+assembled for you – a feature aligned with how many lesson planning tools provide resource
+libraries and attachments for lessons 7 .
+• Integration with Weekly Plan: The resource management is integrated with weekly planning. As
+soon as activities are placed on the weekly calendar, the system knows to include their resources in
+the upcoming week’s needs. If the teacher modifies the plan (e.g. removes an activity or adds a new
+one), the resource list updates in real-time. This dynamic update means the teacher can trust that
+the checklist is always current. The UI might show a small indicator on the weekly planner screen like
+“Resources prepared: 5/7” if some files aren’t downloaded or something – but a simpler approach is
+just to have the teacher explicitly open the resource view.
+• UI for Resource Lists: The Weekly Prep interface will likely present the information in a clear list
+format. It could be a pop-up modal or a dedicated page. For each day, it lists each activity and
+
+7
+
+indents the required items, or just a big list broken by day. Important is that each item is clear and
+actionable. For printables, each file name could be a link to open/preview it (in case teacher wants to
+see it) and a checkbox for “printed/done”. For physical materials, just a checkbox. Possibly, a “Print
+All” and “Mark All as Prepared” button can help quickly handle things when done. The UI should also
+allow exporting the resource checklist itself to PDF or printing it, for teachers who like a paper
+checklist on their desk.
+• Example: Suppose in the upcoming week the teacher has planned: Monday – a math worksheet,
+Wednesday – a science experiment (needs lab materials), Friday – an art project (needs craft
+supplies). On Friday prior, the teacher clicks “Prep for Next Week” in the system. They see a list:
+• Printables: Math Worksheet.pdf (2 pages), ready to download;
+• Materials: “Science – vinegar (1 bottle), baking soda (1 box), 5 balloons; Art – construction paper (class
+set), markers.” They click “Download All Printables” to get the PDF of the math worksheet, which they
+print. They check off the supplies as they gather them in the classroom. By Monday, they have
+everything in place, thanks to the system’s thorough list.
+Providing these prep tools significantly reduces planning overhead. Instead of manually going through
+each day’s plan and writing a materials list, the teacher gets it auto-generated – contributing to the
+efficiency gains such software offers 14 . It ensures no material or document falls through the cracks,
+which improves lesson execution (no delays due to missing items). Additionally, the digital repository of
+resources means over years the teacher builds up a well-organized collection of lesson materials that can
+be reprinted or reused easily 9 . The teacher could even share or import resources in the future if the
+system is extended (e.g. a district might standardize certain resources which can be loaded into each
+teacher’s system).
+
+Progress Tracking and Adaptive Scheduling
+Tracking progress toward curriculum goals is essential in this system. This module monitors which activities
+and milestones have been completed and uses that information to adapt future scheduling. It acts as a
+continuous pacing guide and early warning system if things fall behind.
+• Completion Tracking: As the teacher executes the lesson plans, they can mark activities as
+completed (or skipped, or postponed). The UI will make this easy – for example, each activity in a
+day plan could have a checkbox or a “Done” button next to it. At the end of each day (or week), the
+teacher can quickly tick off what was accomplished. If something was not done as planned (e.g. ran
+out of time), the teacher can indicate that (perhaps marking it as “deferred”). Completed activities are
+recorded in the database, tied to date and any notes (the teacher might input a quick reflection like
+“needed more time” or “students struggled with this concept”). The system uses this data to update
+progress.
+• Progress Dashboard: The system will maintain a dashboard or overview of progress for each
+subject and milestone. This could be represented by progress bars or percentage completion
+indicators. For example, a milestone that had 5 activities might show “3/5 activities completed – 60%”
+and perhaps color-code based on how it aligns with the timeline (green if on track, yellow if slightly
+behind, red if significantly behind schedule). Progress can be measured by number of activities or by
+hours covered versus estimated hours – the latter can be more precise. If a milestone was estimated
+
+8
+
+10 hours and the teacher marked 5 hours of activities done, it’s 50% complete. The dashboard might
+be accessible in the Curriculum Planner screen or a dedicated Progress screen, giving at-a-glance
+status of all milestones.
+• Dynamic Adaptation & Alerts: One of the powerful features is using progress data to adapt the
+schedule. If the teacher is falling behind on a milestone (say the target date is two weeks away but
+only 40% of activities done), the system will generate alerts or suggestions. For instance, the next
+time the teacher opens the Weekly Planner, the system might flag that milestone as urgent –
+increasing the priority of its activities in the suggestion list (e.g. it may suggest two activities from
+that milestone instead of one). It could also display a message like “Milestone ‘Weather and Climate’
+is behind schedule. Consider adding an extra Science session or extending the target date.” In
+essence, the software acts like a GPS recalculating the route: if you’re off track, it finds ways to get
+you back on track. This adaptive scheduling could include automatically bumping planned lessons to
+later or freeing up time for catch-up. For example, if Math is ahead but Science is behind, it might
+suggest borrowing a slot from Math to do Science this week (the teacher, of course, would confirm
+any such change). The flexibility to bump or extend lessons is important for real classroom scenarios
+13 ; our system will incorporate that by allowing the calendar to shift when needed (with the
+teacher’s approval).
+• Schedule Adjustments: If progress issues are detected, the system can facilitate adjustments like:
+• Moving a pending activity to an earlier date (if a milestone is behind, schedule its remaining activities
+sooner).
+• Extending a milestone’s target date (with a note that this may affect year-end goals).
+• Adding a review or remediation activity if the teacher notes students didn’t master something (this
+could be manual but the system can suggest if an assessment indicates low mastery).
+• Conversely, if a milestone is completed early, the system might either advance the target (finishing
+ahead of time) or allow the teacher to insert enrichment activities or start the next unit sooner.
+All these adjustments are logged so the teacher can see a history of changes in the plan. The design
+ensures that no milestone silently falls by the wayside – the software will keep it visible until addressed.
+• Analytics and Reports: The progress data can also be used to generate reports or insights. For
+example, a teacher might want to see at mid-year which subjects are most behind or ahead. A report
+could show “Math: 50% of milestones reached by mid-year, on track; Science: 40% done, behind by 2
+weeks relative to targets.” This helps in realigning priorities. Additionally, the system could track
+student-facing progress if each activity is tied to outcomes (though tracking individual student
+performance is beyond our current scope, focusing on curriculum coverage rather than assessment).
+However, tying activities to curriculum standards would allow a teacher to report on standards
+coverage (some advanced lesson planners do this 17 , but for simplicity we assume tracking at
+milestone level).
+• UI for Progress: A visual dashboard will likely present each subject as a section, with each milestone
+in a timeline or list. Possibly, a calendar timeline for the year with milestones plotted on it (target
+dates) and a marker for today’s date could help visualize if some are slipping past the deadline.
+Alternatively, a simple list with progress bars and colored status (On Track / Behind / Ahead). The
+teacher can click a milestone to get more details (e.g. which activities are done, which remain, and
+
+9
+
+the notes on each). The UI should naturally draw the teacher’s attention to any problem areas – e.g.
+sorting or highlighting overdue milestones at the top.
+• Notifications: The system may also issue gentle reminders. For example, if a week passes with
+certain scheduled activities not marked done, it could ask “Did you complete all planned activities
+last week? If not, consider rescheduling them.” This ensures data stays accurate and plans are
+adjusted promptly. Notifications could be within the app or via email if configured.
+Adaptation in Practice: Suppose by October, the teacher sees that the Social Studies milestone
+“Community and Government” was supposed to be done by end of October, but only half the activities were
+completed and there’s one week left. The system highlights this in red on the dashboard. In the weekly
+suggestion, it puts all remaining Social Studies activities for that milestone as top suggestions for that final
+week, perhaps even suggesting to integrate them or use an extra lesson slot. The teacher follows the
+suggestion and loads the week with more Social Studies to catch up. In another case, maybe Math is way
+ahead because students excelled – the teacher might mark the milestone done early, and the system will
+then not suggest further activities from it and might move on to the next milestone or allow using math
+time for enrichment. This dynamic approach ensures curriculum coverage is balanced and aligned with
+goals, a feature that teaching software can facilitate by providing real-time analytics and adjustments 17 .
+Ultimately, the Progress Tracking module provides a safety net for the teacher’s planning. By maintaining a
+dynamic record of progress toward curriculum milestones, it relieves the teacher from manually crosschecking plans against long-term goals – the system does it continuously. And by suggesting schedule
+adjustments when needed, it helps avoid last-minute rushes or incomplete syllabus coverage. This kind of
+data-driven adjustment is noted as a key benefit of classroom planning software, allowing educators to
+adapt strategies to meet learning objectives on time 17 . It essentially turns static lesson plans into a living
+plan that responds to the realities of classroom pacing.
+
+Parent Communication Support
+Keeping parents informed and engaged is an important aspect of elementary teaching. This system
+includes features to facilitate easy parent communications, especially via periodic newsletters
+summarizing classroom activities. The aim is to reduce the additional work of composing updates and
+ensure parents get a window into their child’s learning.
+• Automatic Newsletter Drafting: The system can generate a draft newsletter content based on
+the activities completed over a chosen time frame (e.g. since the last newsletter was sent). The
+teacher can set a cadence (perhaps bi-weekly or monthly). When it’s time to create a newsletter, the
+teacher opens the Newsletter Generator module and selects the date range (for example, “Oct 1 –
+Oct 15”). The system then compiles a summary such as:
+• Math: “We finished Unit 2 on Addition. Students played a fun Addition Bingo and took a quiz – look
+out for their scores in their folders. Next, we begin Unit 3 on Time.”
+• Science: “We started our Weather unit and did an experiment creating a water cycle in a bowl. See
+the photo of our mini water cycle in action!”
+• English: “We read Chapters 4-6 of Charlotte’s Web and learned about character traits. Ask your child
+about Charlotte’s character and how she helps Wilbur.”
+
+10
+
+This content is generated by pulling the completed activities and their descriptions (especially those marked
+with public notes by the teacher). The system might include milestone names (e.g. “finished Unit 2” as
+above) to give parents a sense of progress. Essentially, it transforms the teacher’s planning data into parentfriendly language. The generation can follow a template structure: for each subject or each major project, a
+couple of sentences highlighting what was done and learned. This saves the teacher from writing from
+scratch every time. It’s known that classroom newsletters are a great way for families to get a glimpse
+of classroom activities 18 , and our system streamlines their creation.
+• Public Notes on Activities: When the teacher plans or completes an activity, they can add a public
+note – a brief commentary intended for sharing with parents. For example, after a science
+experiment, the teacher might write, “Students were excited to see the chemical reaction – they all
+participated enthusiastically!” or a note like “Johnny’s mom helped donate the materials for this
+experiment – thank you!”. These notes are stored with the activity and flagged as shareable. The
+newsletter generator will incorporate them, either as part of the narrative or as quotes/bullet points.
+This feature means the teacher can jot down communication points in real time (during planning or
+right after a lesson) and not worry about forgetting them when writing a newsletter later. It
+essentially builds a narrative log of the class’s journey.
+• Photo Uploads: The teacher can also upload photos associated with activities (ensuring any school
+privacy policies are followed, of course). For instance, a photo of students performing a science
+experiment or an art project outcome can be attached to that activity’s record. In the newsletter
+generator, the teacher can choose some of these photos to include. The system could provide small
+thumbnail previews in the draft, and if selected, it will place them appropriately in the final output
+(e.g. inline with the text or in a gallery section). Including visuals makes newsletters more engaging
+for parents, and teachers often already take photos for their own documentation. This system will
+organize those photos by activity/date, so retrieving them for the newsletter is simple.
+• Newsletter Editing and Export: After the initial draft is generated, the teacher can edit the content
+in a rich-text editor to add a personal touch, ensure tone is right, and add any additional messages
+(like reminders for upcoming events, student shout-outs, etc.). The UI here would be similar to a
+simple word processor, with formatting options. Once finalized, the teacher can export the
+newsletter to PDF or DOCX format for distribution. PDF is ideal for emailing or printing, while DOCX
+allows further editing or combining with other school communications if needed. The export
+function will apply a nice template or letterhead (possibly the school’s logo or class name at the top).
+The teacher can also copy the content to an email if they prefer to send it directly.
+The system may also keep a history of newsletters sent, with dates, so the teacher can review what was
+communicated previously (and ensure no redundant info).
+• Parent-Facing Portal (Future): In a standalone single-teacher scenario, direct email or printed
+newsletters are likely. However, we note that the data structure here could support a simple parent
+portal in the future – where parents could log in to view these updates, or where the teacher could
+push a “post” to a class blog. Many apps (e.g. Seesaw, ClassDojo) allow sharing updates with families
+in real-time 19 . While that’s beyond our scope, our design with public notes and photos per activity
+could be the backbone of such a feed. For now, the newsletter is the compiled approach to reach all
+parents not using an app.
+
+11
+
+• Other Communication Aids: Aside from newsletters, the system can help with quick
+communication bits. For example, it might allow the teacher to print a summary of completed
+work to send home in students’ folders (some teachers send weekly work folders 20 ). The teacher
+could print a one-page summary of “This week, we did X, Y, Z” as a cover sheet for the folder.
+Because our system knows what was done, it can generate that easily (possibly the same content as
+a newsletter but in brief bullet form). Another feature could be a behavior or incident log that the
+teacher could note and include in communication, but that might be beyond the academic focus of
+this tool. We concentrate on curriculum and classwork updates.
+Why this matters: Keeping parents informed has been shown to improve school-home relationships and
+even student performance 21 . By integrating communication into the planning workflow, our system
+ensures that outreach is not an afterthought. The teacher doesn’t have to recall two weeks of activities – the
+system remembers and drafts it for them. This lowers the barrier to regular communication, hopefully
+leading to more consistent updates. In essence, the system acts like a ghostwriter for the teacher’s
+classroom newsletter, which the teacher can then personalize. Planning software often highlights parentteacher communication features for exactly this reason – it saves time and keeps parents in the loop 22
+23 . Here we fulfill that by generating newsletters that summarize completed work and highlight class
+achievements.
+UI Mockup – Newsletter Editor: Imagine a screen with a dropdown to select the date range of content to
+include (defaulting to “since last newsletter”). The teacher clicks “Generate Draft” and a text area populates
+with paragraphs sorted by subject. Each subject paragraph mentions milestones or activities done. Photos
+that were marked for sharing might appear as small placeholders [Photo1]. The teacher can click on a
+placeholder to confirm inclusion and perhaps add a caption. They can type additional text anywhere. Above
+the editor, there could be a preview button to see a PDF view with nicer formatting (e.g. a header “Ms.
+Smith’s Grade 4 Newsletter – Oct 15, 2025”). Once satisfied, the teacher clicks “Export PDF”. The system then
+uses a template to layout the text and images into a well-formatted PDF document. The teacher can then
+distribute that via email or print copies. The entire process might take only a few minutes, as opposed to
+writing a newsletter from scratch which could take an hour.
+
+Emergency Sub Plan Generation
+One standout feature is a one-click emergency sub plan generator, which addresses those unexpected
+times when the teacher cannot attend class (due to illness or emergency). The goal is to rapidly produce a
+standalone day plan that a substitute teacher can use to run the class with minimal confusion, ensuring
+continuity for students even in the teacher’s absence.
+• Stored Class Information: To make a sub plan truly “one-click,” the system will rely on information
+already stored or pre-configured by the teacher. This includes the daily timetable (already in the
+system), seating charts or attendance lists if available, and any special instructions (for example,
+“John is allergic to peanuts” or “Lineup order for fire drill is posted by the door”). Some of this might
+be beyond our system’s core, but at least a teacher can input general classroom notes for subs in a
+profile section.
+• Sub Plan Content: When the teacher activates the emergency sub plan (likely by clicking a
+“Generate Sub Plan for [date]” button), the system does the following:
+
+12
+
+• Determines which day’s schedule to use (by default, “today” or the next school day if done in
+advance).
+• Checks if there were already lessons planned for that day in the weekly plan. If yes, it will retrieve
+those along with their details.
+• Compiles a full-day schedule document. This will list each period of the day, the subject, and the
+activity or alternative task. Crucially, it will add more detailed instructions suitable for someone who
+is not the regular teacher. For example, if the regular plan says “Math – Multiplication Bingo game,”
+the sub plan might elaborate: “Math (9:00–9:45) – Multiplication Bingo. Instructions: Use the bingo
+cards in the top drawer. Students know the game; have one student explain rules. Winners get a
+sticker from the reward box.” The system can pull these instructions from a combination of teacher’s
+notes (if the teacher had entered “how to run this activity” in a note field) or from a template if not
+provided (maybe the teacher pre-enters generic instructions for each type of activity).
+• If no lesson was planned or if certain planned activities might not be suitable for a sub (e.g. a
+complicated science lab), the system will substitute it with a fallback activity. We could maintain a
+small bank of generic sub-friendly activities for each subject (like a reading or review exercise). For
+instance, if a science experiment was scheduled, the sub plan might replace it with “Have students
+read chapter 2 of the science textbook and answer questions on page 50” – something any sub can
+manage. The teacher can help define these fallback options beforehand (perhaps an “Emergency
+Plan” template for each subject).
+• Include any general instructions: e.g. routine procedures (attendance, recess duty, dismissal
+instructions). The teacher might set these up once, and the system appends them every time a sub
+plan is generated. For example: “Take attendance at 8:50 on the sheet provided. If a student is
+absent, send a note to the office. Lunch is at 12:00 – students line up by the door,” etc.
+• One-Click Generation & Output: All the above content is assembled automatically when the
+teacher clicks the emergency button. The output is a well-organized document (PDF/DOCX) that the
+teacher (or an administrator) can print or email to the substitute. It should be formatted clearly,
+likely with each period as a heading, and step-by-step details. If any worksheets or materials are
+needed for those lessons, the system will also bundle those (just like weekly resources). For example,
+if the sub is to give a worksheet for math, the system will include that in the package. In effect, the
+sub should receive everything needed: the day’s schedule, instructions, and any printables.
+• User Experience: From the teacher’s perspective, ideally they invoke this with minimal effort.
+Perhaps a button on the main dashboard labeled “Emergency Sub Plan”. If they are at home sick,
+they could remotely trigger it (assuming the system is accessible, maybe not if fully offline – an area
+to consider if making a cloud-connected version). Alternatively, having printed emergency plans
+ready is common. Our system could encourage printing a generic sub plan in advance too. However,
+the unique advantage here is if an emergency occurs mid-year, the system can generate a sub plan
+that’s context-aware – reflecting what the class is currently doing, rather than a static plan from
+September.
+• Preparation for Use: We can integrate a setup where at the start of the year, the teacher fills some
+“Emergency Plan Template” information: like preferred easy activities for each subject that can be
+done anytime (e.g. silent reading, educational games, review worksheets), location of materials, and
+any do’s/don’ts for subs. This information will be stored and used to enrich any auto-generated sub
+plan. For example, if no specific plan exists for a given subject that day, it will pick from these pre-set
+emergency activities.
+
+13
+
+• Relation to Normal Plans: If the teacher already had a detailed plan for the day but can’t be there,
+often that plan can be used by the sub. The system should incorporate the day’s planned activities
+where possible (since they align with the curriculum), but it will present them with more detail. Also,
+the teacher might choose not to have the sub do certain activities (maybe the teacher wants to do an
+important lesson themselves later). In that case, the teacher (if able to) could toggle off those
+activities and let the system replace them with filler activities. In an ideal scenario, the teacher could
+do this from home through the interface. But if not, at least the default logic might exclude activities
+marked as “teacher-dependent” (we could have a flag on activities that they shouldn’t be done by a
+sub). For now, we can assume the system uses whatever is in the schedule, since in an emergency
+the teacher might not get to tweak anything – better to do something than nothing.
+• Example Scenario: It’s 6 AM and the teacher is feeling very ill and won’t make it to school. Using her
+tablet at home, she opens the app and hits “Emergency Sub Plan – Generate for Today”. The app
+creates a document:
+• 8:50 – Homeroom: Take attendance (roster attached). Collect homework from yesterday (assignment
+was Chapter 3 questions).
+• 9:00 – Math: Multiplication Bingo game. Instructions: ... (as above, with detail). If time left, have
+students solve problems on board.
+• 9:45 – English: Reading comprehension. Instructions: Students will silently read chapter 4 of
+“Charlotte’s Web”. Then hand out the question sheet (attached) and have them work individually.
+• 10:30 – Recess: (The plan notes the time but no action needed by sub except supervision).
+• ... and so on for the whole day.
+• Finally, a section “End of Day: Please leave any notes of what was completed or any issues. Ensure
+students pack up at 2:45,” etc. She emails this PDF to the school secretary, who prints it for the
+substitute. All necessary worksheets (question sheet) are attached, and materials (bingo cards) are
+referenced which the sub can find because the instructions say where.
+Incorporating this feature acknowledges a real need – teachers often have emergency sub plans prepared
+because planning a day’s lessons while sick is hard. By automating it, we make a stressful situation easier.
+As one resource humorously notes, “Teachers aren't machines. Sometimes we even have to take a day off...
+This generator was developed to make that day a little easier” 24 . Our system’s one-click sub plan does
+exactly that: it makes an emergency day easier by removing the last-minute scramble. Not many older
+systems had this, but our design shows it’s feasible by leveraging the existing data in the system.
+From a design standpoint, this feature will require the combination of scheduling logic and stored
+templated instructions. It’s a contained piece of functionality that doesn’t interfere with normal operations
+(except maybe a setting panel for emergency info). It should be tested thoroughly to ensure the output is
+clear and comprehensive for a substitute who may have zero familiarity with the class. Ideally, if the system
+scales, this could tie into a feature like Planbook’s where a substitute can be given access to view the day’s
+plans online 25 – but for now, a printed plan is sufficient.
+
+14
+
+Activity Note Keeping (Private & Public Notes)
+Throughout all the above modules, the ability for the teacher to record notes is integrated. This section
+highlights how activity note-keeping works for both private planning purposes and public sharing
+purposes.
+• Private Notes (Teacher’s Planning Notes): Each activity and possibly each milestone will have a
+field for private notes. These are visible only to the teacher within the system. Private notes serve
+multiple roles: lesson reflections, reminders, or planning tips. For example, after teaching an activity,
+the teacher might note “Students struggled with section 2 of the worksheet – re-teach this next year”
+or “This activity took 15 min longer than planned” or even classroom management notes like “Use
+the timer to keep this activity on track.” During planning, the teacher might write notes like “Prepare
+extra examples on board” or “This ties in with last week’s story, mention that connection.” The
+system does not use private notes for any automation (except perhaps to carry over as hints if
+reusing the lesson next year), so they truly are the teacher’s personal space. This encourages
+reflective practice; many educators jot reflections to improve future instruction, and having it in the
+same system as the plans means they’re easy to find when needed.
+• Public Notes (For Sharing/Communication): As discussed in the parent communication section,
+public notes are intended for an audience beyond the teacher – primarily parents, but could also be
+for students or admin. These notes are typically about the outcome of the activity or something
+notable that can be shared publicly. The teacher can mark a note as public when adding it. For
+instance, a note like “The class really enjoyed this story and asked to read another by the same
+author!” could be public (suitable for a newsletter blurb). Or “We built bridges in science class – check
+out the photos!” is a public note prompt that pairs with uploaded pictures. Public notes might also
+include positive anecdotes (“Every student contributed at least one idea in the discussion today –
+proud moment!”) or general statements of what was achieved (“Completed Chapter 5 – now
+proficient in long division”). The system aggregates these for the newsletter. It could also be
+imagined that if a principal asks what the class has been doing, the teacher can quickly filter public
+notes to give a summary.
+• Separation and Security: It’s crucial that private notes remain private. The system’s data model will
+clearly distinguish them, and any sharing function (like the newsletter generator) will only pull from
+public notes. Even if an activity has both types of notes, only the designated public one goes out.
+This allows the teacher to be candid in private notes without worry. For example, a private note
+might say “This took too long” whereas the public note for the same activity might say “We had a
+lively discussion and will continue tomorrow” – different tone for different audiences.
+• User Interface for Notes: When viewing or editing an activity (in any context, be it in the curriculum
+library or on a week’s plan), the UI will show two text fields for notes: “Private Note” and “Public Note
+(optional)”. They can have placeholders to guide usage (e.g. “Private notes are only visible to you”
+under that field). Possibly an icon (a lock icon for private). The teacher can type in these fields
+anytime. They might fill some during planning (like reminders), and then after completing the
+activity, they might add a reflection or outcome in either field. The notes are saved with timestamps.
+In a daily plan view, perhaps an activity will show its notes if any (private notes could appear as a
+small italic text only the teacher sees, maybe in the app; public notes might not show there because
+they are more for external communication).
+
+15
+
+• Using Notes in Other Modules:
+• The Progress Tracking module could allow the teacher to view notes when reviewing a milestone’s
+progress, helping them remember context (e.g. if behind schedule, check notes to see if any delays
+were due to something).
+• The Weekly Planner might show a small icon if an activity has a note, indicating additional info.
+• The Parent Communication uses public notes for content.
+• The Emergency Sub Plan might pull from private notes labeled for subs. We might add a special
+note field per activity like “Sub note” if needed, or simply the teacher includes sub-specific
+instructions in a note and flags it. In Planbook, teachers can add specific instructional notes for
+substitutes 25 – our system can mimic that by considering any private note that is tagged for sub
+(or maybe any note in a special “Emergency instructions” field for the day).
+• Note Retrieval and Search: Over the year, the teacher might accumulate a lot of notes.
+Implementing a search function (especially for private notes) would be helpful – e.g. search all notes
+for “timing” to find where they wrote about activities running long. This is a nice-to-have that can be
+incorporated if time permits. At minimum, notes are organized by their activity/milestone context
+which itself is organized by subject, so browsing is straightforward.
+• Exporting/Printing Notes: We could allow the teacher to export all notes for a subject or milestone
+(for archiving or sharing with a replacement teacher if needed). For instance, if a teacher moves
+schools, they might want a document with all their lesson notes for the next teacher. Because our
+system can output to docx/PDF, generating such a report is feasible.
+Overall Benefit: Integrating note-keeping into the planning system encourages reflective teaching and
+robust communication. Instead of sticky notes or separate journals, everything is in one place. Teachers
+who revisit their plans each year will find such notes invaluable for continuous improvement (e.g., “last year
+this lab was too hard – simplify it this year”). It also contributes to building an “institutional memory” if the
+data is ever shared or scaled to multiple teachers 9 . The presence of a public note option reminds
+teachers to frame pieces of the learning in parent-friendly ways as they go, which can directly feed the
+communication loop.
+The note-keeping feature is simple in implementation (just text fields stored in the database), but it’s a
+linchpin for connecting the system’s planning side with the human aspect of teaching. It ensures that while
+the software handles structure and suggestions, the teacher’s professional insight is captured and can be
+leveraged, maintaining the balance between automation and teacher control.
+
+User Interface Components & Workflow Summary
+To tie everything together, here’s a summary of the major UI components and how a teacher would typically
+navigate through them in the course of using the system:
+• Dashboard: A landing page that gives an overview – perhaps showing today’s plan at a glance,
+upcoming milestones or alerts (e.g. “Milestone X due in 5 days”), and quick links to features like “Plan
+Next Week” or “Generate Newsletter”. It serves as a starting point each day.
+
+16
+
+• Curriculum Planner Screen: As described, with subject lists, milestones, and activities. UI
+components here include: Subject dropdown or list, Add Subject/Milestone buttons, milestone cards
+with progress bars, and activity tables under each milestone. This is used at the beginning of term
+and occasionally to adjust milestones or add new activities.
+• Timetable Setup Dialog: An interface (maybe under Settings or first-run wizard) where the teacher
+sets the weekly schedule. Components: a grid for weekdays vs time slots, or a form to enter each
+subject’s class times. Possibly a wizard that asks “How many periods do you teach per day? Enter
+times… Now assign subjects to each period.”
+• Weekly Planner Page: A dual-pane interface with the activity suggestion list on one side and the
+week calendar on the other. Components: filter controls (checkboxes or dropdowns for style/skills/
+resources), a list of suggested activities (each with an “Add” button or draggable handle), a week
+calendar view (with drag-and-drop slots). Also an “Auto-fill” button could be offered to automatically
+place all suggestions into the calendar (the teacher can tweak after). Once filled, a “Finalize Week”
+action might lead to locking the plan and generating day plans.
+• Daily Plan View: Although daily plans can be printed, the UI can also show a daily breakdown
+(perhaps clicking on a day in the week view opens the details). Components: timeline of the day’s
+periods with entries, checkboxes to mark done, and quick links to open attachments (like an icon
+next to an activity to view its PDF). This view is used by the teacher each day, possibly on a tablet in
+class, to guide lessons. It might include a “notes” button next to each activity to quickly add a
+reflection on the fly.
+• Resource Prep View: Accessible via a “Resources” button on the weekly plan page or main menu.
+Components: lists of materials and files, grouped by day or category, checkboxes to mark prepared,
+and a “Download All Printables” button. Possibly also a print button for the list itself.
+• Progress Dashboard: A page showing all subjects and milestones with their progress. Components:
+progress bars, colored status indicators, maybe a calendar timeline. Possibly interactive (click
+milestone to see details). This might also allow adjusting target dates (e.g. drag a milestone bar
+along the timeline to new date if needed).
+• Newsletter/Communication Editor: A rich-text editor as described, with maybe subject headers
+auto-filled and text. Components: a date range selector, an “auto-generate” button, the text editor
+(with formatting toolbar), and an “Insert Photo” option that opens a gallery of photos uploaded in
+that date range. Then export options (PDF, DOCX).
+• Emergency Plan Button: Could be prominently placed (maybe an icon of an emergency kit) or in a
+menu. If clicked, possibly a confirmation “Generate sub plan for [date]? Yes/No” to avoid accidental
+trigger. After generation, it shows a preview of the plan (so the teacher or admin can review) with an
+option to print or export immediately.
+• Settings & Templates: A section for various configurations: managing emergency plan templates
+(like entering those fallback activities instructions), class info, default newsletter intro/outro text,
+backup/export data options, etc. While not heavily discussed earlier, providing a way to backup the
+data (maybe export all plans to PDF or JSON) is wise in a standalone system for data security.
+
+17
+
+Workflow Diagram (Textual): The general flow of usage through a school year might be:
+1. Initial Setup: Teacher enters subjects and milestones in Curriculum Planner -> Sets up timetable ->
+Inputs any templates (newsletter, emergency notes).
+2. Weekly Routine: Each week, go to Weekly Planner -> Review suggestions -> Add/arrange activities in
+calendar -> Check Resource list -> Print needed materials -> Teach using Daily Plan -> Mark activities
+done and add notes each day.
+3. Ongoing: Check Progress Dashboard periodically -> Adjust plans if needed (if behind/ahead). System
+alerts if falling behind, which influences next week’s suggestions.
+4. Communication: Every few weeks, open Newsletter Editor -> generate content -> tweak and send to
+parents. Also possibly send quick updates with public notes as needed.
+5. Emergency: If needed, hit Emergency Plan -> get sub plan -> class runs smoothly in teacher’s
+absence.
+6. Year-end: Export or archive the year’s plans and notes -> prepare for next year by copying/adapting
+the curriculum plan for the new year (the system could facilitate rollover of content, since everything
+is stored and can be reused 13 ).
+Throughout these steps, the UI remains consistent and simple, guiding the teacher rather than
+overwhelming them. By integrating all functions, the teacher doesn’t have to jump between different tools
+(e.g. separate lesson planner, separate parent newsletter maker, etc.) – it’s all in one, which is a big usability
+win 10 .
+
+Technical Considerations and Future Scaling
+• Export & Interoperability: All content (plans, checklists, newsletters) can be exported to common
+formats (PDF, DOCX). This ensures the teacher can share or print any information easily, addressing
+the requirement of portability. PDF export is especially useful for printing full semester or weekly
+plans to have a physical copy or to submit to a principal 15 . DOCX export allows the teacher to do
+final edits in Word if needed or combine documents. We will use robust libraries for this (ensuring
+formatting like tables for schedules come out neatly).
+• Data Backup: The standalone system could include an option to backup the entire database (e.g.
+produce a file that the teacher can save externally, or automatically backup to a chosen cloud drive).
+This is important in case the device is lost or the teacher gets a new computer.
+• Security & Privacy: Since it’s a single-user local app, data is stored on the teacher’s device. We
+should encrypt any sensitive data (though it’s mostly lesson info, not highly sensitive). If student
+names or photos are included, protecting those is crucial – perhaps offer password protection on the
+app. If scaling to multi-user, proper authentication and data partitioning per user becomes needed.
+• Modular Design for Scaling: The codebase is organized by modules corresponding to features,
+which communicate through defined interfaces (for example, the Weekly Planner module queries
+the Curriculum module for suggestions; the Progress module feeds into the Planning module). This
+modularity means to adapt it for multiple teachers, one could introduce a user management module
+and turn the backend into a web server (with minimal changes to module logic). An admin interface
+could be added to view multiple teachers’ curriculum plans (like a principal overseeing lesson plans,
+similar to Planbook’s admin view 26 ). Also, a shared database can be introduced so multiple
+
+18
+
+instances share data (for collaborative planning in a grade team, for example). The UI is already built
+for a single teacher, but could be extended to allow switching between teachers or sharing plans via
+import/export of lesson banks 27 . These possibilities have been considered in the architecture so
+that future development is not hindered by a monolithic design.
+• Tech Stack Summary: We recommend React (or Angular/Vue) for front-end, Node.js for backend
+logic, and SQLite for local storage – this stack balances modern UX with simplicity. For a .NET-centric
+environment (some schools might prefer Windows apps), an alternative stack could be an all-in-one
+C# application using WPF or Blazor for UI and local DB. However, the web-based approach gives
+more flexibility for device type (e.g. iPad use via a browser or wrapped as an app). As noted by
+EdTech solution experts, choosing a robust yet maintainable tech stack is key for performance and
+long-term maintenance 28 3 . Our chosen technologies are widely used and will ensure the app
+runs smoothly with capabilities like offline use, real-time UI updates, and easy packaging.
+• Performance: The application should run efficiently on a typical teacher’s computer or tablet. The
+data volume is not huge (a year’s worth of lesson data, some PDFs). Using client-side rendering
+(React) will make UI interactions quick. Heavy operations like PDF generation might take a moment,
+but that’s acceptable as those are done on demand and not frequently. We will optimize database
+queries (index by dates, etc.) so that pulling weekly plans or progress stats is instantaneous.
+• Workflow Diagrams and Documentation: We will create supporting documentation including
+flowcharts for how an activity moves from curriculum entry -> weekly plan -> completion ->
+newsletter. Additionally, simple UI mockups (wireframes) for each main screen will be drawn to
+refine the design before implementation. This ensures that the development team and stakeholders
+(in this case, perhaps the teacher or a small pilot group) have a clear picture of the end product.
+Given this text plan, translating it into wireframes is straightforward – each bullet under UI
+components could correspond to a sketch of that screen.
+
+Conclusion
+This detailed plan covers the design and implementation strategy for a comprehensive teacher-centric
+planning system. By addressing everything from yearly milestones to daily lessons, and from resource prep
+to parent newsletters, the system will significantly streamline a teacher’s workflow. Crucially, it’s designed
+with a teacher-friendly UI, acknowledging that educators want to save time and reduce complexity. Each
+feature has been grounded in known needs or best practices in education (e.g. curriculum mapping, pacing
+guides, parent communication), and we’ve cited parallels in existing solutions to validate these choices.
+In summary, this system will serve as the teacher’s digital planning partner: it organizes the curriculum,
+suggests weekly lessons, ensures materials are ready 7 , tracks progress and adapts plans 17 , helps
+keep parents informed 22 , and even covers the class on a sick day 24 . All of this is achieved with a
+coherent software architecture (React/Node/SQLite) that can evolve with future requirements. Once
+implemented, a single teacher can plan an entire year’s curriculum and day-to-day activities with
+confidence, knowing nothing will slip through the cracks and their students’ learning journey is well-charted
+and communicated.
+
+19
+
+1
+
+3
+
+4
+
+5
+
+28
+
+Best Tech Stack for Educational Learning Software
+
+https://adamosoft.com/blog/edutech-solutions/educational-learning-software/
+2
+
+12
+
+Our Guide to Lesson Planning, School Software & Education
+
+https://completeeducationsolutions.uk/school-booking-system/lesson-planning-software-education-guide/
+6
+
+7
+
+10
+
+14
+
+17
+
+22
+
+23
+
+17 Features and Benefits of Classroom Planning Software
+
+https://www.scheduleit.com/blog/11271/17-features-and-benefits-of-classroom-planning-software
+8
+
+9
+
+Curriculum Mapping and Lesson Planning - TeacherEase
+
+https://www.teacherease.com/curriculum-mapping-and-lesson-planning.aspx
+11
+
+13
+
+16
+
+25
+
+26
+
+27
+
+Planbook - The Leader in Lesson Planning
+
+https://planbook.com/
+15
+
+What is Planboard and How Can it Be Used to Teach? | Tech & Learning
+
+https://www.techlearning.com/how-to/what-is-planboard-and-how-can-it-be-used-to-teach-tips-and-tricks
+18
+
+19
+
+20
+
+21
+
+The Best Teacher-Parent Communication Tools | Continental
+
+https://www.continentalpress.com/blog/best-teacher-parent-communications-tools/?
+srsltid=AfmBOop1wYNuGozhOMzWURThAQambYcYQWS7Z52v7Wu9i8CKgS5t19xu
+24
+
+Substitute Teaching Daily Plan Generator
+
+https://www.teach-nology.com/web_tools/materials/substitute/daily_plan/
+
+20
+
+

--- a/docs/requirements-traceability-matrix.md
+++ b/docs/requirements-traceability-matrix.md
@@ -1,0 +1,21 @@
+# Requirements Traceability Matrix
+
+This table links each high-level feature from the _Implementation Plan_ to the current implementation or outstanding AGENT tasks.
+
+| Implementation Plan Goal                        | Source Lines            | Status      | Related Tasks/Features                                                 |
+| ----------------------------------------------- | ----------------------- | ----------- | ---------------------------------------------------------------------- |
+| Subject-wise curriculum directory               | impl_plan.txt L9-L10    | Implemented | CRUD API for subjects/milestones/activities (AGENTS-TODO.md L231-L272) |
+| Weekly planning with activity suggestions       | impl_plan.txt L9-L10    | Implemented | Weekly planner automation (AGENTS-TODO.md L527-L579)                   |
+| Automated resource lists                        | impl_plan.txt L9-L10    | Implemented | Resource management system (AGENTS-TODO.md L590-L656)                  |
+| Dynamic progress tracking & adaptive scheduling | impl_plan.txt L9-L10    | Implemented | Progress tracking & alerts (AGENTS-TODO.md L658-L711)                  |
+| Parent newsletter generation                    | impl_plan.txt L9-L10    | Implemented | Newsletter generator (AGENTS-TODO.md L712-L753)                        |
+| One-click emergency sub plans                   | impl_plan.txt L9-L10    | Implemented | Emergency sub plans (AGENTS-TODO.md L758-L778)                         |
+| Robust notekeeping for reflections/comments     | impl_plan.txt L9-L10    | **Missing** | _See new tasks in section 9 of AGENTS-TODO-missing features_           |
+| Data backup option                              | impl_plan.txt L749-L751 | Planned     | Cloud backup integration (AGENTS-TODO.md L816-L820)                    |
+| PDF/DOCX export capability                      | impl_plan.txt L742-L748 | Implemented | Newsletter and sub plan exports (AGENTS-TODO.md L712-L753, L758-L775)  |
+| Authentication & multi-user support             | impl_plan.txt L752      | Planned     | Authentication module (AGENTS-TODO.md L783-L804)                       |
+| Holiday-aware scheduling                        | impl_plan.txt L143      | Planned     | Schedule generation tasks (AGENTS-TODO.md L865-L901)                   |
+| AI curriculum import & clustering               | impl_plan.txt L740-L752 | Planned     | Data extraction & AI integration (AGENTS-TODO.md L830-L864)            |
+| Dashboard & onboarding workflow                 | impl_plan.txt L671-L676 | Planned     | Unified week view & onboarding tasks (AGENTS-TODO-missing… L234-L240)  |
+
+Unlisted plan items were not found in the repository or task list.


### PR DESCRIPTION
## Summary
- document implementation plan mapping in new requirements-traceability-matrix
- add new Notes & Reflection Management section in AGENTS TODO
- include text version of Implementation Plan for reference

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_684757f97748832d936f92b05755486b