### PR TITLE
Implement unified dashboard and onboarding

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import SubjectsPage from './pages/SubjectsPage';
 import SubjectDetailPage from './pages/SubjectDetailPage';
 import MilestoneDetailPage from './pages/MilestoneDetailPage';
@@ -7,13 +7,14 @@ import NotificationsPage from './pages/NotificationsPage';
 import NewsletterEditor from './pages/NewsletterEditor';
 import DailyPlanPage from './pages/DailyPlanPage';
 import TimetablePage from './pages/TimetablePage';
+import DashboardPage from './pages/DashboardPage';
 import { NotificationProvider } from './contexts/NotificationContext';
 
 export default function App() {
   return (
     <NotificationProvider>
       <Routes>
-        <Route path="/" element={<Navigate to="/subjects" replace />} />
+        <Route path="/" element={<DashboardPage />} />
         <Route path="/subjects" element={<SubjectsPage />} />
         <Route path="/subjects/:id" element={<SubjectDetailPage />} />
         <Route path="/milestones/:id" element={<MilestoneDetailPage />} />

--- a/client/src/__tests__/TeacherOnboardingFlow.test.tsx
+++ b/client/src/__tests__/TeacherOnboardingFlow.test.tsx
@@ -1,0 +1,12 @@
+import { fireEvent, screen } from '@testing-library/react';
+import TeacherOnboardingFlow from '../components/TeacherOnboardingFlow';
+import { renderWithRouter } from '../test-utils';
+
+test('shows and dismisses overlay', () => {
+  localStorage.clear();
+  renderWithRouter(<TeacherOnboardingFlow />);
+  expect(screen.getByText(/Welcome to Teaching Engine/)).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Got it'));
+  expect(screen.queryByText(/Welcome to Teaching Engine/)).not.toBeInTheDocument();
+  expect(localStorage.getItem('onboarded')).toBe('true');
+});

--- a/client/src/__tests__/UnifiedWeekViewComponent.test.tsx
+++ b/client/src/__tests__/UnifiedWeekViewComponent.test.tsx
@@ -1,0 +1,35 @@
+import { screen, fireEvent } from '@testing-library/react';
+import UnifiedWeekViewComponent from '../components/UnifiedWeekViewComponent';
+import { renderWithRouter } from '../test-utils';
+import { vi } from 'vitest';
+
+vi.mock('../components/AutoFillButton', () => {
+  return {
+    default: ({ onGenerated }: { onGenerated: () => void }) => (
+      <button onClick={() => onGenerated()} data-testid="fill">
+        Auto Fill
+      </button>
+    ),
+  };
+});
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual('../api');
+  return {
+    ...actual,
+    useLessonPlan: () => ({
+      data: { id: 1, weekStart: '2025-01-01', schedule: [] },
+      refetch: vi.fn(),
+    }),
+    useSubjects: () => ({ data: [] }),
+    useTimetable: () => ({ data: [] }),
+    useGenerateNewsletter: () => ({ mutate: vi.fn() }),
+  };
+});
+
+test('shows prompts after generating plan', () => {
+  renderWithRouter(<UnifiedWeekViewComponent />);
+  expect(screen.queryByText('Next steps:')).toBeNull();
+  fireEvent.click(screen.getByTestId('fill'));
+  expect(screen.getByText('Next steps:')).toBeInTheDocument();
+});

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -361,6 +361,11 @@ export const useNewsletters = () =>
     queryFn: async () => (await api.get('/newsletters')).data,
   });
 
+export const useGenerateNewsletter = () =>
+  useMutation((data: { startDate: string; endDate: string }) =>
+    api.post('/newsletters/generate', data).then((r) => r.data as Newsletter),
+  );
+
 export interface TimetableSlot {
   id: number;
   day: number;

--- a/client/src/components/TeacherOnboardingFlow.tsx
+++ b/client/src/components/TeacherOnboardingFlow.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export default function TeacherOnboardingFlow() {
+  const [visible, setVisible] = useState(() => localStorage.getItem('onboarded') !== 'true');
+  const dismiss = () => {
+    localStorage.setItem('onboarded', 'true');
+    setVisible(false);
+  };
+  if (!visible) return null;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 space-y-2 max-w-sm">
+        <h2 className="text-lg font-bold">Welcome to Teaching Engine</h2>
+        <ol className="list-decimal pl-5 space-y-1 text-sm">
+          <li>Auto-fill your week plan.</li>
+          <li>Prepare materials.</li>
+          <li>Send a newsletter.</li>
+        </ol>
+        <button className="px-2 py-1 bg-blue-600 text-white" onClick={dismiss}>
+          Got it
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/UnifiedWeekViewComponent.tsx
+++ b/client/src/components/UnifiedWeekViewComponent.tsx
@@ -1,0 +1,117 @@
+import { useState, useMemo } from 'react';
+import { DndContext, DragEndEvent } from '@dnd-kit/core';
+import {
+  useLessonPlan,
+  useSubjects,
+  Activity,
+  getWeekStartISO,
+  useTimetable,
+  useGenerateNewsletter,
+} from '../api';
+import ActivitySuggestionList from './ActivitySuggestionList';
+import WeekCalendarGrid from './WeekCalendarGrid';
+import AutoFillButton from './AutoFillButton';
+import WeeklyMaterialsChecklist from './WeeklyMaterialsChecklist';
+import DownloadPrintablesButton from './DownloadPrintablesButton';
+import PlannerNotificationBanner from './PlannerNotificationBanner';
+import { toast } from 'sonner';
+
+export default function UnifiedWeekViewComponent() {
+  const [weekStart, setWeekStart] = useState(() => getWeekStartISO(new Date()));
+  const { data: plan, refetch } = useLessonPlan(weekStart);
+  const subjects = useSubjects().data ?? [];
+  const { data: timetable } = useTimetable();
+  const genNewsletter = useGenerateNewsletter();
+  const [showPrompts, setShowPrompts] = useState(false);
+
+  const activities = useMemo(() => {
+    const all: Record<number, Activity> = {};
+    subjects.forEach((s) =>
+      s.milestones.forEach((m) => m.activities.forEach((a) => (all[a.id] = a))),
+    );
+    return all;
+  }, [subjects]);
+
+  const handleDrop = (day: number, activityId: number) => {
+    if (!plan) return;
+    const slots = timetable?.filter((t) => t.day === day && t.subjectId) ?? [];
+    const used = new Set(plan.schedule.filter((s) => s.day === day).map((s) => s.slotId));
+    const slot = slots.find((s) => !used.has(s.id));
+    if (!slot) {
+      toast.error('No available slot');
+      return;
+    }
+    const schedule = [
+      ...plan.schedule,
+      { id: 0, day, slotId: slot.id, activityId, activity: activities[activityId] },
+    ];
+    fetch(`/api/lesson-plans/${plan.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ schedule }),
+    }).then(() => refetch());
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const day = event.over?.data?.current?.day;
+    if (typeof day === 'number') {
+      handleDrop(day, Number(event.active.id));
+    }
+  };
+
+  const handleGenerated = () => {
+    refetch();
+    setShowPrompts(true);
+  };
+
+  const createNewsletter = () => {
+    const end = new Date(weekStart);
+    end.setDate(end.getDate() + 6);
+    genNewsletter.mutate(
+      { startDate: weekStart, endDate: getWeekStartISO(end) },
+      { onSuccess: () => toast.success('Newsletter draft created') },
+    );
+  };
+
+  const schedule = plan?.schedule ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2 items-center">
+        <input
+          type="date"
+          value={weekStart}
+          onChange={(e) => setWeekStart(getWeekStartISO(new Date(e.target.value)))}
+          className="border p-1"
+        />
+        <AutoFillButton weekStart={weekStart} onGenerated={handleGenerated} />
+      </div>
+      {showPrompts && (
+        <div className="bg-blue-50 p-2 flex gap-2 items-center text-sm">
+          <span>Next steps:</span>
+          <button className="px-2 py-1 bg-blue-600 text-white" onClick={createNewsletter}>
+            Generate Newsletter
+          </button>
+          <DownloadPrintablesButton weekStart={weekStart} />
+        </div>
+      )}
+      <PlannerNotificationBanner />
+      <DndContext onDragEnd={handleDragEnd}>
+        <WeekCalendarGrid schedule={schedule} activities={activities} timetable={timetable} />
+        {!plan && (
+          <p data-testid="no-plan-message" className="text-sm text-gray-600">
+            No plan for this week. Click Auto Fill to generate one.
+          </p>
+        )}
+        {plan && (
+          <div className="space-y-2 my-4">
+            <DownloadPrintablesButton weekStart={weekStart} />
+            <WeeklyMaterialsChecklist weekStart={weekStart} />
+          </div>
+        )}
+        <h2>Suggestions</h2>
+        <ActivitySuggestionList activities={Object.values(activities)} />
+      </DndContext>
+    </div>
+  );
+}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,0 +1,11 @@
+import UnifiedWeekViewComponent from '../components/UnifiedWeekViewComponent';
+import TeacherOnboardingFlow from '../components/TeacherOnboardingFlow';
+
+export default function DashboardPage() {
+  return (
+    <div className="relative">
+      <TeacherOnboardingFlow />
+      <UnifiedWeekViewComponent />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `UnifiedWeekViewComponent` combining weekly planner, materials and newsletter prompts
- add `TeacherOnboardingFlow` overlay for first‑time users
- add `DashboardPage` and set as app home route
- add `useGenerateNewsletter` API helper
- test onboarding and post‑planning prompts

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68475d3e270c832d8505192c0a3d0a12