### PR TITLE
Add calendar event integration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@tanstack/react-query": "^5.37.0",
     "axios": "^1.6.8",
+    "date-fns": "^2.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -469,3 +469,33 @@ export const useDeleteNote = () => {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['notes'] }),
   });
 };
+
+export interface CalendarEvent {
+  id: number;
+  title: string;
+  description?: string;
+  start: string;
+  end: string;
+  allDay: boolean;
+  eventType: 'PD_DAY' | 'ASSEMBLY' | 'TRIP' | 'HOLIDAY' | 'CUSTOM';
+  source: 'MANUAL' | 'ICAL_FEED' | 'SYSTEM';
+}
+
+export const useCalendarEvents = (from: string, to: string) =>
+  useQuery<CalendarEvent[]>({
+    queryKey: ['calendarEvents', from, to],
+    queryFn: async () =>
+      (
+        await api.get('/calendar-events', {
+          params: { from, to },
+        })
+      ).data,
+  });
+
+export const useAddCalendarEvent = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: Omit<CalendarEvent, 'id'>) => api.post('/calendar-events', data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['calendarEvents'] }),
+  });
+};

--- a/client/src/components/CalendarViewComponent.tsx
+++ b/client/src/components/CalendarViewComponent.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { startOfMonth, endOfMonth, eachDayOfInterval } from 'date-fns';
+import { CalendarEvent, useCalendarEvents } from '../api';
+import EventEditorModal from './EventEditorModal';
+
+interface Props {
+  month: Date;
+}
+
+export default function CalendarViewComponent({ month }: Props) {
+  const [editorOpen, setEditorOpen] = useState(false);
+  const from = startOfMonth(month).toISOString();
+  const to = endOfMonth(month).toISOString();
+  const { data: events } = useCalendarEvents(from, to);
+
+  const days = eachDayOfInterval({ start: new Date(from), end: new Date(to) });
+  const grouped: Record<string, CalendarEvent[]> = {};
+  events?.forEach((e) => {
+    const d = e.start.split('T')[0];
+    if (!grouped[d]) grouped[d] = [];
+    grouped[d].push(e);
+  });
+
+  return (
+    <div className="border rounded p-2">
+      <button
+        className="mb-2 px-2 py-1 bg-blue-500 text-white rounded"
+        onClick={() => setEditorOpen(true)}
+      >
+        + Add Event
+      </button>
+      <div className="grid grid-cols-7 gap-1 text-sm">
+        {days.map((d) => (
+          <div key={d.toISOString()} className="border p-1 min-h-16">
+            <div className="font-bold text-xs">{d.getDate()}</div>
+            {(grouped[d.toISOString().split('T')[0]] || []).map((ev) => (
+              <div key={ev.id} className="text-xs bg-gray-200 rounded mt-1 px-1" title={ev.title}>
+                {ev.title}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      {editorOpen && <EventEditorModal onClose={() => setEditorOpen(false)} />}
+    </div>
+  );
+}

--- a/client/src/components/EventEditorModal.tsx
+++ b/client/src/components/EventEditorModal.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import Dialog from './Dialog';
+import { useAddCalendarEvent } from '../api';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function EventEditorModal({ onClose }: Props) {
+  const [title, setTitle] = useState('');
+  const [date, setDate] = useState('');
+  const mutation = useAddCalendarEvent();
+
+  const submit = () => {
+    if (!date || !title) return;
+    mutation.mutate({
+      title,
+      start: `${date}T00:00:00.000Z`,
+      end: `${date}T23:59:59.000Z`,
+      allDay: true,
+      eventType: 'CUSTOM',
+      source: 'MANUAL',
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <div className="space-y-2 w-64">
+        <h2 className="text-lg">Add Event</h2>
+        <input
+          className="border p-1 w-full"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          type="date"
+          className="border p-1 w-full"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={submit}>
+          Save
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/client/src/components/WeekCalendarGrid.tsx
+++ b/client/src/components/WeekCalendarGrid.tsx
@@ -1,13 +1,14 @@
-import type { WeeklyScheduleItem, Activity, TimetableSlot } from '../api';
+import type { WeeklyScheduleItem, Activity, TimetableSlot, CalendarEvent } from '../api';
 import { useDroppable } from '@dnd-kit/core';
 
 interface Props {
   schedule: WeeklyScheduleItem[];
   activities: Record<number, Activity>;
   timetable?: TimetableSlot[];
+  events?: CalendarEvent[];
 }
 
-export default function WeekCalendarGrid({ schedule, activities, timetable }: Props) {
+export default function WeekCalendarGrid({ schedule, activities, timetable, events }: Props) {
   const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
   return (
     <div className="grid grid-cols-5 gap-2">
@@ -18,6 +19,7 @@ export default function WeekCalendarGrid({ schedule, activities, timetable }: Pr
         const daySlot = timetable?.find((t) => t.day === idx);
         const blocked = daySlot && !daySlot.subjectId;
         const label = daySlot?.subject?.name ?? (blocked ? 'Prep' : '');
+        const dayEvents = events?.filter((e) => new Date(e.start).getUTCDay() === (idx + 1) % 7);
         const { isOver, setNodeRef } = useDroppable({
           id: `day-${idx}`,
           data: { day: idx },
@@ -31,6 +33,11 @@ export default function WeekCalendarGrid({ schedule, activities, timetable }: Pr
           >
             <span>{d}</span>
             {label && <div className="text-xs">{label}</div>}
+            {dayEvents?.map((ev) => (
+              <div key={ev.id} className="text-xs bg-yellow-200 w-full mt-1" title={ev.title}>
+                {ev.title}
+              </div>
+            ))}
             {items.map((it) => (
               <div key={it.id} className="mt-1 text-sm">
                 {activities[it.activityId]?.title}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,11 +1,13 @@
 import UnifiedWeekViewComponent from '../components/UnifiedWeekViewComponent';
 import TeacherOnboardingFlow from '../components/TeacherOnboardingFlow';
+import CalendarViewComponent from '../components/CalendarViewComponent';
 
 export default function DashboardPage() {
   return (
     <div className="relative">
       <TeacherOnboardingFlow />
       <UnifiedWeekViewComponent />
+      <CalendarViewComponent month={new Date()} />
     </div>
   );
 }

--- a/client/src/pages/WeeklyPlannerPage.tsx
+++ b/client/src/pages/WeeklyPlannerPage.tsx
@@ -1,6 +1,13 @@
 import { useState, useMemo, useEffect } from 'react';
 import { DndContext, DragEndEvent } from '@dnd-kit/core';
-import { useLessonPlan, useSubjects, Activity, getWeekStartISO, useTimetable } from '../api';
+import {
+  useLessonPlan,
+  useSubjects,
+  Activity,
+  getWeekStartISO,
+  useTimetable,
+  useCalendarEvents,
+} from '../api';
 import ActivitySuggestionList from '../components/ActivitySuggestionList';
 import WeekCalendarGrid from '../components/WeekCalendarGrid';
 import AutoFillButton from '../components/AutoFillButton';
@@ -14,6 +21,10 @@ export default function WeeklyPlannerPage() {
   const { data: plan, refetch } = useLessonPlan(weekStart);
   const subjects = useSubjects().data ?? [];
   const { data: timetable } = useTimetable();
+  const { data: events } = useCalendarEvents(
+    weekStart,
+    new Date(new Date(weekStart).getTime() + 6 * 86400000).toISOString(),
+  );
   const activities = useMemo(() => {
     const all: Record<number, Activity> = {};
     subjects.forEach((s) =>
@@ -70,7 +81,12 @@ export default function WeeklyPlannerPage() {
       </div>
       <PlannerNotificationBanner />
       <DndContext onDragEnd={handleDragEnd}>
-        <WeekCalendarGrid schedule={schedule} activities={activities} timetable={timetable} />
+        <WeekCalendarGrid
+          schedule={schedule}
+          activities={activities}
+          timetable={timetable}
+          events={events}
+        />
         {!plan && (
           <p data-testid="no-plan-message" className="text-sm text-gray-600">
             No plan for this week. Click Auto Fill to generate one.

--- a/client/tests/WeeklyPlanner.test.tsx
+++ b/client/tests/WeeklyPlanner.test.tsx
@@ -65,6 +65,7 @@ vi.mock('../src/api', async () => {
     }),
     useGeneratePlan: () => generateState,
     useMaterialDetails: () => ({ data: [] }),
+    useCalendarEvents: () => ({ data: [] }),
     downloadPrintables: vi.fn(),
   };
 });

--- a/packages/database/prisma/migrations/20250610134520_add_calendar_event/migration.sql
+++ b/packages/database/prisma/migrations/20250610134520_add_calendar_event/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "CalendarEvent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "start" DATETIME NOT NULL,
+    "end" DATETIME NOT NULL,
+    "allDay" BOOLEAN NOT NULL DEFAULT false,
+    "eventType" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'MANUAL',
+    "teacherId" INTEGER,
+    "schoolId" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "CalendarEvent_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -172,5 +172,36 @@ model User {
   subjects Subject[]
   milestones Milestone[]
   activities Activity[]
+  events    CalendarEvent[]
+}
+
+enum CalendarEventType {
+  PD_DAY
+  ASSEMBLY
+  TRIP
+  HOLIDAY
+  CUSTOM
+}
+
+enum CalendarEventSource {
+  MANUAL
+  ICAL_FEED
+  SYSTEM
+}
+
+model CalendarEvent {
+  id          Int                 @id @default(autoincrement())
+  title       String
+  description String?
+  start       DateTime
+  end         DateTime
+  allDay      Boolean             @default(false)
+  eventType   CalendarEventType
+  source      CalendarEventSource @default(MANUAL)
+  teacherId   Int?
+  teacher     User?               @relation(fields: [teacherId], references: [id])
+  schoolId    Int?
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       axios:
         specifier: ^1.6.8
         version: 1.9.0
+      date-fns:
+        specifier: ^2.30.0
+        version: 2.30.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -160,6 +163,9 @@ importers:
       node-cron:
         specifier: ^3.0.3
         version: 3.0.3
+      node-ical:
+        specifier: ^0.20.1
+        version: 0.20.1
       nodemailer:
         specifier: ^6.9.11
         version: 6.10.1
@@ -5954,6 +5960,18 @@ packages:
         integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==,
       }
 
+  moment-timezone@0.5.48:
+    resolution:
+      {
+        integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==,
+      }
+
+  moment@2.30.1:
+    resolution:
+      {
+        integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==,
+      }
+
   ms@2.0.0:
     resolution:
       {
@@ -6023,6 +6041,12 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-ical@0.20.1:
+    resolution:
+      {
+        integrity: sha512-NrXgzDJd6XcyX9kDMJVA3xYCZmntY7ghA2BOdBeYr3iu8tydHOAb+68jPQhF9V2CRQ0/386X05XhmLzQUN0+Hw==,
+      }
 
   node-int64@0.4.0:
     resolution:
@@ -6897,6 +6921,12 @@ packages:
     engines: { node: '>=18.0.0', npm: '>=8.0.0' }
     hasBin: true
 
+  rrule@2.8.1:
+    resolution:
+      {
+        integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==,
+      }
+
   rrweb-cssom@0.7.1:
     resolution:
       {
@@ -7746,6 +7776,13 @@ packages:
         integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==,
       }
     engines: { node: '>= 0.4.0' }
+
+  uuid@10.0.0:
+    resolution:
+      {
+        integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
+      }
+    hasBin: true
 
   uuid@8.3.2:
     resolution:
@@ -12254,6 +12291,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  moment-timezone@0.5.48:
+    dependencies:
+      moment: 2.30.1
+
+  moment@2.30.1: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -12281,6 +12324,15 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-ical@0.20.1:
+    dependencies:
+      axios: 1.9.0
+      moment-timezone: 0.5.48
+      rrule: 2.8.1
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - debug
 
   node-int64@0.4.0: {}
 
@@ -12771,6 +12823,10 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.42.0
       '@rollup/rollup-win32-x64-msvc': 4.42.0
       fsevents: 2.3.3
+
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
 
   rrweb-cssom@0.7.1: {}
 
@@ -13290,6 +13346,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.11",
     "pdfkit": "^0.17.1",
+    "node-ical": "^0.20.1",
     "pino": "8.21.0",
     "unzipper": "^0.12.3",
     "zod": "3.25.56"

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import notificationRoutes from './routes/notification';
 import newsletterRoutes from './routes/newsletter';
 import timetableRoutes from './routes/timetable';
 import noteRoutes from './routes/note';
+import calendarEventRoutes from './routes/calendarEvent';
 import { scheduleProgressCheck } from './jobs/progressCheck';
 import { scheduleUnreadNotificationEmails } from './jobs/unreadNotificationEmail';
 import { scheduleBackups } from './services/backupService';
@@ -46,6 +47,7 @@ app.use('/api/notifications', notificationRoutes);
 app.use('/api/newsletters', newsletterRoutes);
 app.use('/api/timetable', timetableRoutes);
 app.use('/api/notes', noteRoutes);
+app.use('/api/calendar-events', calendarEventRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/server/src/routes/calendarEvent.ts
+++ b/server/src/routes/calendarEvent.ts
@@ -1,0 +1,90 @@
+import { Router } from 'express';
+import type { VEvent } from 'node-ical';
+import { prisma } from '../prisma';
+import { z } from 'zod';
+import { validate } from '../validation';
+
+const router = Router();
+
+/**
+ * Validation schema for creating calendar events.
+ */
+const eventSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  start: z.string().datetime(),
+  end: z.string().datetime(),
+  allDay: z.boolean().optional().default(false),
+  eventType: z.enum(['PD_DAY', 'ASSEMBLY', 'TRIP', 'HOLIDAY', 'CUSTOM']),
+  source: z.enum(['MANUAL', 'ICAL_FEED', 'SYSTEM']).optional().default('MANUAL'),
+  teacherId: z.number().int().optional(),
+  schoolId: z.number().int().optional(),
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    const events = await prisma.calendarEvent.findMany({
+      where: {
+        ...(from && { start: { gte: new Date(from) } }),
+        ...(to && { end: { lte: new Date(to) } }),
+      },
+      orderBy: { start: 'asc' },
+    });
+    res.json(events);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(eventSchema), async (req, res, next) => {
+  try {
+    const data = req.body as z.infer<typeof eventSchema>;
+    const event = await prisma.calendarEvent.create({
+      data: {
+        title: data.title,
+        description: data.description,
+        start: new Date(data.start),
+        end: new Date(data.end),
+        allDay: data.allDay,
+        eventType: data.eventType,
+        source: data.source,
+        teacherId: data.teacherId,
+        schoolId: data.schoolId,
+      },
+    });
+    res.status(201).json(event);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * Import events from an iCal feed URL and store them as HOLIDAY events.
+ */
+router.post('/sync/ical', async (req, res, next) => {
+  try {
+    const { feedUrl } = req.body as { feedUrl: string };
+    if (!feedUrl) return res.status(400).json({ error: 'feedUrl required' });
+    const ical = await import('node-ical');
+    const data = (await ical.async.fromURL(feedUrl)) as Record<string, VEvent>;
+    const eventsToCreate = Object.values(data)
+      .filter((e): e is VEvent => e.type === 'VEVENT')
+      .map((e) => ({
+        title: e.summary || 'Untitled',
+        description: e.description || undefined,
+        start: new Date(e.start),
+        end: new Date(e.end),
+        allDay: e.datetype === 'date',
+        eventType: 'HOLIDAY' as const,
+        source: 'ICAL_FEED' as const,
+      }));
+    const created = await prisma.calendarEvent.createMany({ data: eventsToCreate });
+    res.json({ imported: created.count });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add CalendarEvent model to database and migration
- expose calendar event APIs with iCal sync
- support calendar events in weekly planner and dashboard calendar view
- mock calendar API in tests

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68483649250c832db4e7614136ac8fdb