### PR TITLE
Implement short week scheduling logic

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -199,12 +199,22 @@ export const useDeleteMilestone = () => {
 };
 
 export const useGeneratePlan = () =>
-  useMutation((weekStart: string) => {
-    const isoWeekStart = getWeekStartISO(new Date(weekStart));
-    return api
-      .post('/lesson-plans/generate', { weekStart: isoWeekStart })
-      .then((res) => res.data as LessonPlan);
-  });
+  useMutation(
+    (data: {
+      weekStart: string;
+      preserveBuffer: boolean;
+      pacingStrategy: 'strict' | 'relaxed';
+    }) => {
+      const isoWeekStart = getWeekStartISO(new Date(data.weekStart));
+      return api
+        .post('/lesson-plans/generate', {
+          weekStart: isoWeekStart,
+          pacingStrategy: data.pacingStrategy,
+          preserveBuffer: data.preserveBuffer,
+        })
+        .then((res) => res.data as LessonPlan);
+    },
+  );
 
 export const useLessonPlan = (weekStart: string) =>
   useQuery<LessonPlan | undefined>({

--- a/client/src/components/AutoFillButton.tsx
+++ b/client/src/components/AutoFillButton.tsx
@@ -4,29 +4,39 @@ import axios from 'axios';
 
 interface Props {
   weekStart: string;
+  preserveBuffer: boolean;
+  pacingStrategy: 'strict' | 'relaxed';
   onGenerated?: (plan: LessonPlan) => void;
 }
 
-export default function AutoFillButton({ weekStart, onGenerated }: Props) {
+export default function AutoFillButton({
+  weekStart,
+  preserveBuffer,
+  pacingStrategy,
+  onGenerated,
+}: Props) {
   const generate = useGeneratePlan();
   const handleClick = () =>
-    generate.mutate(weekStart, {
-      onSuccess: (plan) => {
-        toast.success('Plan generated! Review the materials list.');
-        onGenerated?.(plan);
+    generate.mutate(
+      { weekStart, preserveBuffer, pacingStrategy },
+      {
+        onSuccess: (plan) => {
+          toast.success('Plan generated! Review the materials list.');
+          onGenerated?.(plan);
+        },
+        onError: (err) => {
+          if (
+            axios.isAxiosError(err) &&
+            err.response?.status === 400 &&
+            typeof err.response.data?.error === 'string'
+          ) {
+            toast.error(err.response.data.error);
+          } else {
+            toast.error('Failed to generate plan');
+          }
+        },
       },
-      onError: (err) => {
-        if (
-          axios.isAxiosError(err) &&
-          err.response?.status === 400 &&
-          typeof err.response.data?.error === 'string'
-        ) {
-          toast.error(err.response.data.error);
-        } else {
-          toast.error('Failed to generate plan');
-        }
-      },
-    });
+    );
 
   return (
     <button

--- a/client/src/components/UnifiedWeekViewComponent.tsx
+++ b/client/src/components/UnifiedWeekViewComponent.tsx
@@ -18,6 +18,8 @@ import { toast } from 'sonner';
 
 export default function UnifiedWeekViewComponent() {
   const [weekStart, setWeekStart] = useState(() => getWeekStartISO(new Date()));
+  const [preserveBuffer, setPreserveBuffer] = useState(true);
+  const [skipLow, setSkipLow] = useState(true);
   const { data: plan, refetch } = useLessonPlan(weekStart);
   const subjects = useSubjects().data ?? [];
   const { data: timetable } = useTimetable();
@@ -84,7 +86,26 @@ export default function UnifiedWeekViewComponent() {
           onChange={(e) => setWeekStart(getWeekStartISO(new Date(e.target.value)))}
           className="border p-1"
         />
-        <AutoFillButton weekStart={weekStart} onGenerated={handleGenerated} />
+        <AutoFillButton
+          weekStart={weekStart}
+          preserveBuffer={preserveBuffer}
+          pacingStrategy={skipLow ? 'relaxed' : 'strict'}
+          onGenerated={handleGenerated}
+        />
+      </div>
+      <div className="flex gap-4 items-center">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={preserveBuffer}
+            onChange={(e) => setPreserveBuffer(e.target.checked)}
+          />
+          Preserve daily buffer block
+        </label>
+        <label className="inline-flex items-center gap-2">
+          <input type="checkbox" checked={skipLow} onChange={(e) => setSkipLow(e.target.checked)} />
+          Skip lowest priority activity on short weeks
+        </label>
       </div>
       {showPrompts && (
         <div className="bg-blue-50 p-2 flex gap-2 items-center text-sm">

--- a/client/src/pages/WeeklyPlannerPage.tsx
+++ b/client/src/pages/WeeklyPlannerPage.tsx
@@ -18,6 +18,8 @@ import { toast } from 'sonner';
 
 export default function WeeklyPlannerPage() {
   const [weekStart, setWeekStart] = useState(() => getWeekStartISO(new Date()));
+  const [preserveBuffer, setPreserveBuffer] = useState(true);
+  const [skipLow, setSkipLow] = useState(true);
   const { data: plan, refetch } = useLessonPlan(weekStart);
   const subjects = useSubjects().data ?? [];
   const { data: timetable } = useTimetable();
@@ -77,7 +79,26 @@ export default function WeeklyPlannerPage() {
           onChange={(e) => setWeekStart(getWeekStartISO(new Date(e.target.value)))}
           className="border p-1"
         />
-        <AutoFillButton weekStart={weekStart} onGenerated={() => refetch()} />
+        <AutoFillButton
+          weekStart={weekStart}
+          preserveBuffer={preserveBuffer}
+          pacingStrategy={skipLow ? 'relaxed' : 'strict'}
+          onGenerated={() => refetch()}
+        />
+      </div>
+      <div className="flex gap-4 items-center">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={preserveBuffer}
+            onChange={(e) => setPreserveBuffer(e.target.checked)}
+          />
+          Preserve daily buffer block
+        </label>
+        <label className="inline-flex items-center gap-2">
+          <input type="checkbox" checked={skipLow} onChange={(e) => setSkipLow(e.target.checked)} />
+          Skip lowest priority activity on short weeks
+        </label>
       </div>
       <PlannerNotificationBanner />
       <DndContext onDragEnd={handleDragEnd}>

--- a/server/tests/planningEngine.test.ts
+++ b/server/tests/planningEngine.test.ts
@@ -1,5 +1,9 @@
 import { prisma } from '../src/prisma';
-import { generateWeeklySchedule } from '../src/services/planningEngine';
+import {
+  generateWeeklySchedule,
+  filterAvailableBlocksByCalendar,
+} from '../src/services/planningEngine';
+import { getMilestoneUrgency } from '../src/services/progressAnalytics';
 
 describe('planning engine', () => {
   beforeAll(async () => {
@@ -51,7 +55,16 @@ describe('planning engine', () => {
         { title: 'A6', milestoneId: milestone.id },
       ],
     });
-    const schedule = await generateWeeklySchedule();
+    const slots = await prisma.timetableSlot.findMany();
+    const blocks = filterAvailableBlocksByCalendar(slots, []);
+    const urg = await getMilestoneUrgency();
+    const priority = new Map(urg.map((u) => [u.id, u.urgency]));
+    const schedule = await generateWeeklySchedule({
+      availableBlocks: blocks,
+      milestonePriorities: priority,
+      pacingStrategy: 'relaxed',
+      preserveBuffer: false,
+    });
     expect(schedule.length).toBe(5);
     const days = new Set(schedule.map((s) => s.day));
     expect(days.size).toBe(5);
@@ -86,7 +99,16 @@ describe('planning engine', () => {
     const a2 = await prisma.activity.create({ data: { title: 'A2', milestoneId: m2.id } });
     const a3 = await prisma.activity.create({ data: { title: 'A3', milestoneId: m1.id } });
     const a4 = await prisma.activity.create({ data: { title: 'A4', milestoneId: m2.id } });
-    const schedule = await generateWeeklySchedule();
+    const slots = await prisma.timetableSlot.findMany();
+    const blocks = filterAvailableBlocksByCalendar(slots, []);
+    const urg = await getMilestoneUrgency();
+    const priority = new Map(urg.map((u) => [u.id, u.urgency]));
+    const schedule = await generateWeeklySchedule({
+      availableBlocks: blocks,
+      milestonePriorities: priority,
+      pacingStrategy: 'relaxed',
+      preserveBuffer: false,
+    });
     const ids = schedule.map((s) => s.activityId);
     const i1 = ids.indexOf(a1.id);
     const i2 = ids.indexOf(a2.id);
@@ -122,8 +144,71 @@ describe('planning engine', () => {
     const aSoon = await prisma.activity.create({ data: { title: 'A1', milestoneId: dueSoon.id } });
     const aLater = await prisma.activity.create({ data: { title: 'A2', milestoneId: later.id } });
 
-    const schedule = await generateWeeklySchedule();
+    const slots = await prisma.timetableSlot.findMany();
+    const blocks = filterAvailableBlocksByCalendar(slots, []);
+    const urg = await getMilestoneUrgency();
+    const priority = new Map(urg.map((u) => [u.id, u.urgency]));
+    const schedule = await generateWeeklySchedule({
+      availableBlocks: blocks,
+      milestonePriorities: priority,
+      pacingStrategy: 'relaxed',
+      preserveBuffer: false,
+    });
     expect(schedule[0].activityId).toBe(aSoon.id);
     expect(schedule[1].activityId).toBe(aLater.id);
+  });
+
+  it('adds buffer blocks and drops low priority when week is short', async () => {
+    await prisma.weeklySchedule.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.timetableSlot.deleteMany();
+    await prisma.calendarEvent.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+
+    const subj = await prisma.subject.create({ data: { name: 'B' } });
+    const milestone = await prisma.milestone.create({
+      data: { title: 'MB', subjectId: subj.id },
+    });
+    const slotData = [] as { day: number; startMin: number; endMin: number; subjectId: number }[];
+    for (const day of [0, 1, 2, 3]) {
+      slotData.push({ day, startMin: 540, endMin: 600, subjectId: subj.id });
+      slotData.push({ day, startMin: 610, endMin: 670, subjectId: subj.id });
+    }
+    await prisma.timetableSlot.createMany({ data: slotData });
+    await prisma.calendarEvent.create({
+      data: {
+        title: 'PD',
+        start: new Date('2024-03-22T00:00:00Z'),
+        end: new Date('2024-03-22T23:59:59Z'),
+        allDay: true,
+        eventType: 'PD_DAY',
+      },
+    });
+    await prisma.activity.createMany({
+      data: Array.from({ length: 6 }, (_, i) => ({
+        title: `A${i + 1}`,
+        milestoneId: milestone.id,
+      })),
+    });
+
+    const slots = await prisma.timetableSlot.findMany();
+    const events = await prisma.calendarEvent.findMany();
+    const blocks = filterAvailableBlocksByCalendar(slots, events);
+    const urg = await getMilestoneUrgency();
+    const priority = new Map(urg.map((u) => [u.id, u.urgency]));
+
+    const schedule = await generateWeeklySchedule({
+      availableBlocks: blocks,
+      milestonePriorities: priority,
+      pacingStrategy: 'relaxed',
+      preserveBuffer: true,
+    });
+
+    const bufferCount = schedule.filter((s) => s.activityId === 0).length;
+    expect(bufferCount).toBe(4);
+    const assigned = schedule.filter((s) => s.activityId !== 0).map((s) => s.activityId);
+    expect(assigned.length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- add planner utilities for calendar filtering and buffer slots
- update weekly schedule generator to accept options
- pass options from lesson plan route
- expose buffer/omit toggles in planner UI
- adjust tests for new algorithm

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68483b1017bc832db3b7bf9ff9355922