### PR TITLE
Add teacher unavailability model and API

### DIFF
--- a/packages/database/prisma/migrations/20250610142410_unavailable_blocks/migration.sql
+++ b/packages/database/prisma/migrations/20250610142410_unavailable_blocks/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "UnavailableBlock" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "teacherId" INTEGER,
+    "date" DATETIME NOT NULL,
+    "startMin" INTEGER NOT NULL,
+    "endMin" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "blockType" TEXT NOT NULL,
+    "affectedStudentIds" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UnavailableBlock_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -173,6 +173,7 @@ model User {
   milestones Milestone[]
   activities Activity[]
   events    CalendarEvent[]
+  unavailableBlocks UnavailableBlock[]
 }
 
 enum CalendarEventType {
@@ -203,5 +204,24 @@ model CalendarEvent {
   schoolId    Int?
   createdAt   DateTime            @default(now())
   updatedAt   DateTime            @updatedAt
+}
+
+enum UnavailableBlockType {
+  TEACHER_ABSENCE
+  STUDENT_PULL_OUT
+}
+
+model UnavailableBlock {
+  id                Int                  @id @default(autoincrement())
+  teacherId         Int?
+  teacher           User?               @relation(fields: [teacherId], references: [id])
+  date              DateTime
+  startMin          Int
+  endMin            Int
+  reason            String
+  blockType         UnavailableBlockType
+  affectedStudentIds String?
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import newsletterRoutes from './routes/newsletter';
 import timetableRoutes from './routes/timetable';
 import noteRoutes from './routes/note';
 import calendarEventRoutes from './routes/calendarEvent';
+import unavailableBlockRoutes from './routes/unavailableBlock';
 import { scheduleProgressCheck } from './jobs/progressCheck';
 import { scheduleUnreadNotificationEmails } from './jobs/unreadNotificationEmail';
 import { scheduleBackups } from './services/backupService';
@@ -48,6 +49,7 @@ app.use('/api/newsletters', newsletterRoutes);
 app.use('/api/timetable', timetableRoutes);
 app.use('/api/notes', noteRoutes);
 app.use('/api/calendar-events', calendarEventRoutes);
+app.use('/api/unavailable-blocks', unavailableBlockRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -33,7 +33,12 @@ router.post('/generate', async (req, res, next) => {
         end: { gte: startDate },
       },
     });
-    const availableBlocks = filterAvailableBlocksByCalendar(slots, events);
+    const unavail = await prisma.unavailableBlock.findMany({
+      where: {
+        date: { gte: startDate, lte: endDate },
+      },
+    });
+    const availableBlocks = filterAvailableBlocksByCalendar(slots, events, unavail);
     const urg = await getMilestoneUrgency();
     const priorityMap = new Map(urg.map((u) => [u.id, u.urgency]));
     const scheduleData = await generateWeeklySchedule({

--- a/server/src/routes/unavailableBlock.ts
+++ b/server/src/routes/unavailableBlock.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express';
+import { prisma } from '../prisma';
+import { z } from 'zod';
+import { validate } from '../validation';
+
+const router = Router();
+
+const blockSchema = z.object({
+  date: z.string().datetime(),
+  startMin: z.number().int().min(0).max(1440),
+  endMin: z.number().int().min(1).max(1440),
+  reason: z.string().min(1),
+  blockType: z.enum(['TEACHER_ABSENCE', 'STUDENT_PULL_OUT']),
+  teacherId: z.number().int().optional(),
+  affectedStudentIds: z.number().array().optional(),
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const from = req.query.from as string | undefined;
+    const to = req.query.to as string | undefined;
+    const blocks = await prisma.unavailableBlock.findMany({
+      where: {
+        ...(from && { date: { gte: new Date(from) } }),
+        ...(to && { date: { lte: new Date(to) } }),
+      },
+      orderBy: { date: 'asc' },
+    });
+    res.json(
+      blocks.map((b) => ({
+        ...b,
+        affectedStudentIds: b.affectedStudentIds
+          ? (JSON.parse(b.affectedStudentIds) as number[])
+          : undefined,
+      })),
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(blockSchema), async (req, res, next) => {
+  try {
+    const data = req.body as z.infer<typeof blockSchema>;
+    const block = await prisma.unavailableBlock.create({
+      data: {
+        date: new Date(data.date),
+        startMin: data.startMin,
+        endMin: data.endMin,
+        reason: data.reason,
+        blockType: data.blockType,
+        teacherId: data.teacherId,
+        affectedStudentIds: data.affectedStudentIds
+          ? JSON.stringify(data.affectedStudentIds)
+          : undefined,
+      },
+    });
+    res.status(201).json({
+      ...block,
+      affectedStudentIds: data.affectedStudentIds,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -355,3 +355,19 @@ describe('Notes API', () => {
     expect(del.status).toBe(204);
   });
 });
+
+describe('Unavailable Blocks API', () => {
+  it('creates and lists blocks', async () => {
+    const create = await request(app).post('/api/unavailable-blocks').send({
+      date: '2025-02-03T00:00:00.000Z',
+      startMin: 540,
+      endMin: 600,
+      reason: 'Workshop',
+      blockType: 'TEACHER_ABSENCE',
+    });
+    expect(create.status).toBe(201);
+    const list = await request(app).get('/api/unavailable-blocks?from=2025-02-03&to=2025-02-03');
+    expect(list.status).toBe(200);
+    expect(list.body.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `UnavailableBlock` DB model and migration
- expose `/api/unavailable-blocks` endpoints
- include unavailability in weekly plan generation
- filter timetable blocks by calendar events and unavailability
- test new API and planning engine logic

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68483f2dec8c832dbcf80028b1ed2a09