### PR TITLE
Implement year-at-a-glance sharing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import NewsletterEditor from './pages/NewsletterEditor';
 import NewsletterDraftViewer from './pages/NewsletterDraftViewer';
 import DailyPlanPage from './pages/DailyPlanPage';
 import TimetablePage from './pages/TimetablePage';
+import YearAtAGlancePage from './pages/YearAtAGlancePage';
 import DashboardPage from './pages/DashboardPage';
 import NotesPage from './pages/NotesPage';
 import { NotificationProvider } from './contexts/NotificationContext';
@@ -22,6 +23,7 @@ export default function App() {
         <Route path="/milestones/:id" element={<MilestoneDetailPage />} />
         <Route path="/planner" element={<WeeklyPlannerPage />} />
         <Route path="/timetable" element={<TimetablePage />} />
+        <Route path="/year" element={<YearAtAGlancePage />} />
         <Route path="/daily" element={<DailyPlanPage />} />
         <Route path="/notes" element={<NotesPage />} />
         <Route path="/notifications" element={<NotificationsPage />} />

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -526,3 +526,24 @@ export const useAddCalendarEvent = () => {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['calendarEvents'] }),
   });
 };
+
+export interface YearPlanEntry {
+  id: number;
+  teacherId: number;
+  entryType: 'UNIT' | 'ASSESSMENT' | 'EVENT';
+  title: string;
+  start: string;
+  end: string;
+  colorCode?: string | null;
+}
+
+export const useYearPlan = (teacherId: number, year: number) =>
+  useQuery<YearPlanEntry[]>({
+    queryKey: ['yearPlan', teacherId, year],
+    queryFn: async () => (await api.get('/year-plan', { params: { teacherId, year } })).data,
+  });
+
+export const useShareYearPlan = () =>
+  useMutation(({ teacherId, year }: { teacherId: number; year: number }) =>
+    api.post('/share/year-plan', { teacherId, year }).then((r) => r.data),
+  );

--- a/client/src/components/CalendarViewComponent.tsx
+++ b/client/src/components/CalendarViewComponent.tsx
@@ -5,17 +5,19 @@ import EventEditorModal from './EventEditorModal';
 
 interface Props {
   month: Date;
+  events?: CalendarEvent[];
 }
 
-export default function CalendarViewComponent({ month }: Props) {
+export default function CalendarViewComponent({ month, events }: Props) {
   const [editorOpen, setEditorOpen] = useState(false);
   const from = startOfMonth(month).toISOString();
   const to = endOfMonth(month).toISOString();
-  const { data: events } = useCalendarEvents(from, to);
+  const fetch = useCalendarEvents(from, to);
+  const evts = events ?? fetch.data;
 
   const days = eachDayOfInterval({ start: new Date(from), end: new Date(to) });
   const grouped: Record<string, CalendarEvent[]> = {};
-  events?.forEach((e) => {
+  evts?.forEach((e) => {
     const d = e.start.split('T')[0];
     if (!grouped[d]) grouped[d] = [];
     grouped[d].push(e);
@@ -23,12 +25,14 @@ export default function CalendarViewComponent({ month }: Props) {
 
   return (
     <div className="border rounded p-2">
-      <button
-        className="mb-2 px-2 py-1 bg-blue-500 text-white rounded"
-        onClick={() => setEditorOpen(true)}
-      >
-        + Add Event
-      </button>
+      {!events && (
+        <button
+          className="mb-2 px-2 py-1 bg-blue-500 text-white rounded"
+          onClick={() => setEditorOpen(true)}
+        >
+          + Add Event
+        </button>
+      )}
       <div className="grid grid-cols-7 gap-1 text-sm">
         {days.map((d) => (
           <div key={d.toISOString()} className="border p-1 min-h-16">
@@ -41,7 +45,7 @@ export default function CalendarViewComponent({ month }: Props) {
           </div>
         ))}
       </div>
-      {editorOpen && <EventEditorModal onClose={() => setEditorOpen(false)} />}
+      {!events && editorOpen && <EventEditorModal onClose={() => setEditorOpen(false)} />}
     </div>
   );
 }

--- a/client/src/components/YearAtAGlanceComponent.tsx
+++ b/client/src/components/YearAtAGlanceComponent.tsx
@@ -1,0 +1,51 @@
+import { addMonths, endOfMonth, startOfMonth, startOfYear } from 'date-fns';
+import CalendarViewComponent from './CalendarViewComponent';
+import { useYearPlan, YearPlanEntry, CalendarEvent } from '../api';
+
+interface Props {
+  teacherId: number;
+  year: number;
+}
+
+export default function YearAtAGlanceComponent({ teacherId, year }: Props) {
+  const { data } = useYearPlan(teacherId, year);
+  const months = Array.from({ length: 12 }, (_, i) =>
+    addMonths(startOfYear(new Date(year, 0, 1)), i),
+  );
+
+  const getMonthEvents = (month: Date): YearPlanEntry[] => {
+    const start = startOfMonth(month);
+    const end = endOfMonth(month);
+    return (
+      data?.filter((e) => {
+        const s = new Date(e.start);
+        const en = new Date(e.end);
+        return s <= end && en >= start;
+      }) || []
+    );
+  };
+
+  const asCalendarEvents = (entries: YearPlanEntry[]): CalendarEvent[] =>
+    entries.map((e) => ({
+      id: e.id,
+      title: e.title,
+      start: e.start,
+      end: e.end,
+      allDay: true,
+      eventType: 'CUSTOM',
+      source: 'SYSTEM',
+    }));
+
+  return (
+    <div className="space-y-4">
+      {months.map((m) => (
+        <div key={m.toISOString()}>
+          <h3 className="font-bold my-2">
+            {m.toLocaleString('default', { month: 'long', year: 'numeric' })}
+          </h3>
+          <CalendarViewComponent month={m} events={asCalendarEvents(getMonthEvents(m))} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/YearAtAGlancePage.tsx
+++ b/client/src/pages/YearAtAGlancePage.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import YearAtAGlanceComponent from '../components/YearAtAGlanceComponent';
+import { useShareYearPlan } from '../api';
+
+export default function YearAtAGlancePage() {
+  const year = new Date().getUTCFullYear();
+  const [shareUrl, setShareUrl] = useState('');
+  const share = useShareYearPlan();
+
+  const generateShare = async () => {
+    const res = await share.mutateAsync({ teacherId: 1, year });
+    setShareUrl(`${window.location.origin}/share/${res.shareToken}`);
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <div>
+        <button onClick={generateShare} className="px-2 py-1 bg-blue-500 text-white rounded">
+          Share
+        </button>
+        {shareUrl && <div className="mt-2 text-sm break-all">Share Link: {shareUrl}</div>}
+      </div>
+      <YearAtAGlanceComponent teacherId={1} year={year} />
+    </div>
+  );
+}

--- a/packages/database/prisma/migrations/20250610152735_year_plan/migration.sql
+++ b/packages/database/prisma/migrations/20250610152735_year_plan/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "YearPlanEntry" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "teacherId" INTEGER NOT NULL,
+    "entryType" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "start" DATETIME NOT NULL,
+    "end" DATETIME NOT NULL,
+    "colorCode" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "YearPlanEntry_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ShareLink" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "token" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "teacherId" INTEGER NOT NULL,
+    "year" INTEGER NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ShareLink_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShareLink_token_key" ON "ShareLink"("token");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -180,6 +180,8 @@ model User {
   events    CalendarEvent[]
   unavailableBlocks UnavailableBlock[]
   reportDeadlines ReportDeadline[]
+  yearPlanEntries YearPlanEntry[]
+  shareLinks ShareLink[]
 }
 
 enum ActivityType {
@@ -246,3 +248,37 @@ model ReportDeadline {
   milestones       Milestone[]
 }
 
+
+enum YearPlanEntryType {
+  UNIT
+  ASSESSMENT
+  EVENT
+}
+
+model YearPlanEntry {
+  id        Int              @id @default(autoincrement())
+  teacherId Int
+  teacher   User             @relation(fields: [teacherId], references: [id])
+  entryType YearPlanEntryType
+  title     String
+  start     DateTime
+  end       DateTime
+  colorCode String?
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+}
+
+enum ShareLinkType {
+  YEAR_PLAN
+}
+
+model ShareLink {
+  id        Int           @id @default(autoincrement())
+  token     String        @unique
+  type      ShareLinkType
+  teacherId Int
+  teacher   User          @relation(fields: [teacherId], references: [id])
+  year      Int
+  expiresAt DateTime
+  createdAt DateTime      @default(now())
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      nanoid:
+        specifier: ^3.3.4
+        version: 3.3.11
       node-cron:
         specifier: ^3.0.3
         version: 3.0.3

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "node-cron": "^3.0.3",
     "nodemailer": "^6.9.11",
     "pdfkit": "^0.17.1",
+    "nanoid": "^3.3.4",
     "node-ical": "^0.20.1",
     "pino": "8.21.0",
     "unzipper": "^0.12.3",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,8 @@ import noteRoutes from './routes/note';
 import calendarEventRoutes from './routes/calendarEvent';
 import unavailableBlockRoutes from './routes/unavailableBlock';
 import reportDeadlineRoutes from './routes/reportDeadline';
+import yearPlanRoutes from './routes/yearPlan';
+import shareRoutes from './routes/share';
 import { scheduleProgressCheck } from './jobs/progressCheck';
 import { scheduleUnreadNotificationEmails } from './jobs/unreadNotificationEmail';
 import { scheduleNewsletterTriggers } from './jobs/newsletterTrigger';
@@ -58,6 +60,8 @@ app.use('/api/notes', noteRoutes);
 app.use('/api/calendar-events', calendarEventRoutes);
 app.use('/api/unavailable-blocks', unavailableBlockRoutes);
 app.use('/api/report-deadlines', reportDeadlineRoutes);
+app.use('/api/year-plan', yearPlanRoutes);
+app.use('/api/share', shareRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/server/src/routes/share.ts
+++ b/server/src/routes/share.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import { nanoid } from 'nanoid';
+import { prisma } from '../prisma';
+
+const router = Router();
+
+router.post('/year-plan', async (req, res, next) => {
+  try {
+    const { teacherId, year } = req.body as { teacherId: number; year: number };
+    if (!teacherId || !year) return res.status(400).json({ error: 'teacherId and year required' });
+    const token = nanoid(16);
+    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+    await prisma.shareLink.create({
+      data: { token, teacherId, year, type: 'YEAR_PLAN', expiresAt },
+    });
+    res.status(201).json({ shareToken: token, expiresAt });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/src/routes/yearPlan.ts
+++ b/server/src/routes/yearPlan.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { prisma } from '../prisma';
+
+const router = Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const teacherId = Number(req.query.teacherId);
+    const year = Number(req.query.year);
+    if (!teacherId || !year) return res.status(400).json({ error: 'teacherId and year required' });
+    const start = new Date(Date.UTC(year, 0, 1));
+    const end = new Date(Date.UTC(year, 11, 31, 23, 59, 59));
+    const entries = await prisma.yearPlanEntry.findMany({
+      where: {
+        teacherId,
+        start: { lte: end },
+        end: { gte: start },
+      },
+      orderBy: { start: 'asc' },
+    });
+    res.json(entries);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/tests/yearPlan.test.ts
+++ b/server/tests/yearPlan.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import app from '../src/index';
+import { prisma } from '../src/prisma';
+
+beforeAll(async () => {
+  await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
+  await prisma.yearPlanEntry.deleteMany();
+  await prisma.shareLink.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.yearPlanEntry.deleteMany();
+  await prisma.shareLink.deleteMany();
+  await prisma.$disconnect();
+});
+
+describe('year plan routes', () => {
+  it('returns entries for the year', async () => {
+    await prisma.yearPlanEntry.create({
+      data: {
+        teacherId: 1,
+        entryType: 'UNIT',
+        title: 'Numbers to 20',
+        start: new Date('2025-01-06'),
+        end: new Date('2025-01-31'),
+      },
+    });
+    const res = await request(app).get('/api/year-plan').query({ teacherId: 1, year: 2025 });
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    expect(res.body[0].title).toBe('Numbers to 20');
+  });
+
+  it('creates share link', async () => {
+    const res = await request(app).post('/api/share/year-plan').send({ teacherId: 1, year: 2025 });
+    expect(res.status).toBe(201);
+    expect(res.body.shareToken).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add YearPlanEntry and ShareLink schema models
- create GET /year-plan and POST /share/year-plan endpoints
- add YearAtAGlanceComponent and page with share button
- allow CalendarViewComponent to accept pre-fetched events
- provide React Query hooks for year plan data
- include tests for new endpoints

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68484da6b3ac832d9f27a98d8c8987db