### PR TITLE
Implement equipment booking logistics

### DIFF
--- a/packages/database/prisma/migrations/20250610154139_equipment_booking/migration.sql
+++ b/packages/database/prisma/migrations/20250610154139_equipment_booking/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "EquipmentBooking" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "teacherId" INTEGER NOT NULL,
+    "resourceName" TEXT NOT NULL,
+    "neededBy" DATETIME NOT NULL,
+    "leadTimeDays" INTEGER NOT NULL DEFAULT 14,
+    "status" TEXT NOT NULL DEFAULT 'REQUESTED',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "EquipmentBooking_teacherId_fkey" FOREIGN KEY ("teacherId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -182,6 +182,7 @@ model User {
   reportDeadlines ReportDeadline[]
   yearPlanEntries YearPlanEntry[]
   shareLinks ShareLink[]
+  equipmentBookings EquipmentBooking[]
 }
 
 enum ActivityType {
@@ -281,4 +282,22 @@ model ShareLink {
   year      Int
   expiresAt DateTime
   createdAt DateTime      @default(now())
+}
+
+enum EquipmentBookingStatus {
+  REQUESTED
+  CONFIRMED
+  CANCELLED
+}
+
+model EquipmentBooking {
+  id            Int                    @id @default(autoincrement())
+  teacherId     Int
+  teacher       User                   @relation(fields: [teacherId], references: [id])
+  resourceName  String
+  neededBy      DateTime
+  leadTimeDays  Int                    @default(14)
+  status        EquipmentBookingStatus @default(REQUESTED)
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,10 +20,12 @@ import unavailableBlockRoutes from './routes/unavailableBlock';
 import reportDeadlineRoutes from './routes/reportDeadline';
 import yearPlanRoutes from './routes/yearPlan';
 import shareRoutes from './routes/share';
+import equipmentBookingRoutes from './routes/equipmentBooking';
 import { scheduleProgressCheck } from './jobs/progressCheck';
 import { scheduleUnreadNotificationEmails } from './jobs/unreadNotificationEmail';
 import { scheduleNewsletterTriggers } from './jobs/newsletterTrigger';
 import { scheduleReportDeadlineReminders } from './jobs/reportDeadlineReminder';
+import { scheduleEquipmentBookingReminders } from './jobs/bookingReminder';
 import { scheduleBackups } from './services/backupService';
 import logger from './logger';
 import { prisma } from './prisma';
@@ -62,6 +64,7 @@ app.use('/api/unavailable-blocks', unavailableBlockRoutes);
 app.use('/api/report-deadlines', reportDeadlineRoutes);
 app.use('/api/year-plan', yearPlanRoutes);
 app.use('/api/share', shareRoutes);
+app.use('/api/equipment-bookings', equipmentBookingRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
@@ -96,6 +99,7 @@ if (process.env.NODE_ENV !== 'test') {
   scheduleUnreadNotificationEmails();
   scheduleNewsletterTriggers();
   scheduleReportDeadlineReminders();
+  scheduleEquipmentBookingReminders();
   scheduleBackups();
   app.listen(PORT, () => {
     logger.info(`Server listening on port ${PORT}`);

--- a/server/src/jobs/bookingReminder.ts
+++ b/server/src/jobs/bookingReminder.ts
@@ -1,0 +1,36 @@
+import cron from 'node-cron';
+import { prisma } from '../prisma';
+
+/**
+ * Send notifications to remind teachers about upcoming equipment bookings.
+ */
+export async function sendEquipmentBookingReminders() {
+  const today = new Date().toISOString().slice(0, 10);
+  const bookings = await prisma.equipmentBooking.findMany({
+    where: { status: { not: 'CANCELLED' } },
+  });
+  for (const b of bookings) {
+    const needed = new Date(b.neededBy);
+    const lead = b.leadTimeDays;
+    const reminderDates = [
+      new Date(needed.getTime() - lead * 86400000),
+      new Date(needed.getTime() - Math.floor(lead / 2) * 86400000),
+      new Date(needed.getTime() - 86400000),
+    ];
+    if (reminderDates.some((d) => d.toISOString().slice(0, 10) === today)) {
+      await prisma.notification.create({
+        data: {
+          type: 'BOOKING_REMINDER',
+          message: `Prepare booking for ${b.resourceName} needed on ${b.neededBy.toISOString().slice(0, 10)}.`,
+        },
+      });
+    }
+  }
+}
+
+/**
+ * Schedule the booking reminder job to run daily at 8 AM.
+ */
+export function scheduleEquipmentBookingReminders() {
+  cron.schedule('0 8 * * *', sendEquipmentBookingReminders);
+}

--- a/server/src/routes/equipmentBooking.ts
+++ b/server/src/routes/equipmentBooking.ts
@@ -1,0 +1,71 @@
+import { Router } from 'express';
+import { Prisma } from '@teaching-engine/database';
+import { prisma } from '../prisma';
+
+const router = Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const teacherId = req.query.teacherId as string | undefined;
+    const bookings = await prisma.equipmentBooking.findMany({
+      where: teacherId ? { teacherId: Number(teacherId) } : undefined,
+      orderBy: { neededBy: 'asc' },
+    });
+    res.json(bookings);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const { teacherId, resourceName, neededBy, leadTimeDays } = req.body as {
+      teacherId: number;
+      resourceName: string;
+      neededBy: string;
+      leadTimeDays?: number;
+    };
+    if (!teacherId || !resourceName || !neededBy) {
+      return res.status(400).json({ error: 'Invalid data' });
+    }
+    const booking = await prisma.equipmentBooking.create({
+      data: {
+        teacherId,
+        resourceName,
+        neededBy: new Date(neededBy),
+        leadTimeDays: leadTimeDays ?? 14,
+      },
+    });
+    res.status(201).json(booking);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const { resourceName, neededBy, leadTimeDays, status } = req.body as {
+      resourceName?: string;
+      neededBy?: string;
+      leadTimeDays?: number;
+      status?: 'REQUESTED' | 'CONFIRMED' | 'CANCELLED';
+    };
+    const booking = await prisma.equipmentBooking.update({
+      where: { id: Number(req.params.id) },
+      data: {
+        resourceName,
+        neededBy: neededBy ? new Date(neededBy) : undefined,
+        leadTimeDays,
+        status,
+      },
+    });
+    res.json(booking);
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
+    next(err);
+  }
+});
+
+export default router;

--- a/server/tests/equipmentBooking.test.ts
+++ b/server/tests/equipmentBooking.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import app from '../src/index';
+import { prisma } from '../src/prisma';
+
+describe('Equipment Booking API', () => {
+  let teacherId: number;
+
+  beforeAll(async () => {
+    const teacher = await prisma.user.create({
+      data: { email: `eb${Date.now()}@e.com`, password: 'x', name: 'EB' },
+    });
+    teacherId = teacher.id;
+  });
+
+  afterAll(async () => {
+    await prisma.equipmentBooking.deleteMany();
+    await prisma.user.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  it('creates and lists bookings', async () => {
+    const create = await request(app).post('/api/equipment-bookings').send({
+      teacherId,
+      resourceName: 'iPad Cart',
+      neededBy: '2025-03-01T00:00:00.000Z',
+      leadTimeDays: 10,
+    });
+    expect(create.status).toBe(201);
+    const list = await request(app).get(`/api/equipment-bookings?teacherId=${teacherId}`);
+    expect(list.status).toBe(200);
+    expect(list.body.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `EquipmentBooking` model to database
- create routes for equipment booking management
- send daily booking reminders
- hook up reminders and routes in server index
- test equipment booking API

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684851728674832da820cd1318d1416b