### PR TITLE
Implement enhanced sub plan generator

### DIFF
--- a/client/src/__tests__/EmergencyPlanButton.test.tsx
+++ b/client/src/__tests__/EmergencyPlanButton.test.tsx
@@ -1,12 +1,10 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import EmergencyPlanButton from '../components/EmergencyPlanButton';
 import { vi } from 'vitest';
-import axios from 'axios';
+import * as apiModule from '../api';
 
-vi.mock('axios');
-
-const mockedGet = vi.fn().mockResolvedValue({ data: new ArrayBuffer(10) });
-(axios as unknown as { get: typeof mockedGet }).get = mockedGet;
+const mockedPost = vi.fn().mockResolvedValue({ data: new ArrayBuffer(10) });
+(apiModule.api as unknown as { post: typeof mockedPost }).post = mockedPost;
 
 beforeAll(() => {
   // jsdom lacks createObjectURL; provide a stub
@@ -32,8 +30,9 @@ describe('EmergencyPlanButton', () => {
   it('calls API on click', async () => {
     const { getByText } = render(<EmergencyPlanButton />);
     fireEvent.click(getByText('Emergency Plan'));
+    fireEvent.click(getByText('Generate'));
     await waitFor(() => {
-      expect(mockedGet).toHaveBeenCalled();
+      expect(mockedPost).toHaveBeenCalled();
     });
   });
 });

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -234,10 +234,16 @@ export const useLessonPlan = (weekStart: string) =>
     enabled: !!weekStart,
   });
 
+export interface TeacherPreferencesInput {
+  teachingStyles: string[];
+  pacePreference: string;
+  prepTime: number;
+  subPlanContacts?: Record<string, string>;
+  subPlanProcedures?: string;
+}
+
 export const useSavePreferences = () =>
-  useMutation((data: { teachingStyles: string[]; pacePreference: string; prepTime: number }) =>
-    api.post('/preferences', data),
-  );
+  useMutation((data: TeacherPreferencesInput) => api.post('/preferences', data));
 
 export const useUploadResource = () =>
   useMutation(
@@ -547,3 +553,9 @@ export const useShareYearPlan = () =>
   useMutation(({ teacherId, year }: { teacherId: number; year: number }) =>
     api.post('/share/year-plan', { teacherId, year }).then((r) => r.data),
   );
+
+export const fetchSubPlan = (date: string) =>
+  api.post('/subplan/generate', null, {
+    params: { date },
+    responseType: 'blob',
+  });

--- a/client/src/components/EmergencyPlanButton.tsx
+++ b/client/src/components/EmergencyPlanButton.tsx
@@ -1,20 +1,15 @@
-import axios from 'axios';
+import { useState } from 'react';
+import SubPlanGenerator from './SubPlanGenerator';
 
 export default function EmergencyPlanButton() {
-  const handleClick = async () => {
-    const today = new Date().toISOString().slice(0, 10);
-    const res = await axios.get(`/api/subplan?date=${today}`, { responseType: 'blob' });
-    const url = window.URL.createObjectURL(new Blob([res.data], { type: 'application/pdf' }));
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'sub-plan.pdf';
-    a.click();
-    window.URL.revokeObjectURL(url);
-  };
+  const [open, setOpen] = useState(false);
 
   return (
-    <button className="px-2 py-1 bg-red-600 text-white" onClick={handleClick}>
-      Emergency Plan
-    </button>
+    <>
+      <button className="px-2 py-1 bg-red-600 text-white" onClick={() => setOpen(true)}>
+        Emergency Plan
+      </button>
+      {open && <SubPlanGenerator onClose={() => setOpen(false)} />}
+    </>
   );
 }

--- a/client/src/components/SubPlanGenerator.tsx
+++ b/client/src/components/SubPlanGenerator.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import Dialog from './Dialog';
+import { fetchSubPlan } from '../api';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function SubPlanGenerator({ onClose }: Props) {
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [url, setUrl] = useState<string>();
+
+  const generate = async () => {
+    const res = await fetchSubPlan(date);
+    const blob = new Blob([res.data], { type: 'application/pdf' });
+    setUrl(URL.createObjectURL(blob));
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <div className="space-y-2 w-80">
+        <h2 className="text-lg">Generate Sub Plan</h2>
+        <input
+          type="date"
+          className="border p-1 w-full"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <button className="px-2 py-1 bg-blue-500 text-white rounded" onClick={generate}>
+          Generate
+        </button>
+        {url && <iframe src={url} className="w-full h-64 border" />}
+      </div>
+    </Dialog>
+  );
+}

--- a/packages/database/prisma/migrations/20250610162348_add_subplan_fields/migration.sql
+++ b/packages/database/prisma/migrations/20250610162348_add_subplan_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "TeacherPreferences" ADD COLUMN "subPlanContacts" JSONB;
+ALTER TABLE "TeacherPreferences" ADD COLUMN "subPlanProcedures" TEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -88,6 +88,13 @@ model TeacherPreferences {
   teachingStyles String
   pacePreference String
   prepTime       Int
+  /**
+   * JSON object storing contact info for sub plans
+   * e.g. { "principal": "Name", "office": "555-1234" }
+   */
+  subPlanContacts Json?
+  /// Special procedures or notes for substitute teachers
+  subPlanProcedures String?
 }
 
 model Resource {

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { prisma } from '../prisma';
+import { prisma, Prisma } from '../prisma';
 import {
   generateWeeklySchedule,
   filterAvailableBlocksByCalendar,
@@ -121,11 +121,14 @@ router.put('/:id', async (req, res, next) => {
 
 export async function savePreferences(req: Request, res: Response, next: NextFunction) {
   try {
-    const { teachingStyles, pacePreference, prepTime } = req.body as {
-      teachingStyles: string[];
-      pacePreference: string;
-      prepTime: number;
-    };
+    const { teachingStyles, pacePreference, prepTime, subPlanContacts, subPlanProcedures } =
+      req.body as {
+        teachingStyles: string[];
+        pacePreference: string;
+        prepTime: number;
+        subPlanContacts?: Record<string, string>;
+        subPlanProcedures?: string;
+      };
     const prefs = await prisma.teacherPreferences.upsert({
       where: { id: 1 },
       create: {
@@ -133,11 +136,15 @@ export async function savePreferences(req: Request, res: Response, next: NextFun
         teachingStyles: JSON.stringify(teachingStyles),
         pacePreference,
         prepTime,
+        subPlanContacts: subPlanContacts as Prisma.InputJsonValue | undefined,
+        subPlanProcedures,
       },
       update: {
         teachingStyles: JSON.stringify(teachingStyles),
         pacePreference,
         prepTime,
+        subPlanContacts: subPlanContacts as Prisma.InputJsonValue | undefined,
+        subPlanProcedures,
       },
     });
     res.status(201).json(prefs);

--- a/server/src/routes/subplan.ts
+++ b/server/src/routes/subplan.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { prisma } from '../prisma';
 import { generateSubPlanPDF, SubPlanInput } from '../services/subPlanGenerator';
+import { generateSubPlan } from '../services/subPlanService';
 
 const router = Router();
 
@@ -32,6 +33,17 @@ router.post('/', async (req, res, next) => {
       }
     }
     const pdf = await generateSubPlanPDF(data);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.send(pdf);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/generate', async (req, res, next) => {
+  try {
+    const date = (req.query.date as string) || new Date().toISOString().slice(0, 10);
+    const pdf = await generateSubPlan(date);
     res.setHeader('Content-Type', 'application/pdf');
     res.send(pdf);
   } catch (err) {

--- a/server/src/services/subPlanService.ts
+++ b/server/src/services/subPlanService.ts
@@ -1,0 +1,95 @@
+import { prisma } from '../prisma';
+import { generateSubPlanPDF } from './subPlanGenerator';
+import { Prisma } from '@teaching-engine/database';
+
+export interface ScheduleEntry {
+  time: string;
+  activity?: string;
+  note?: string;
+}
+
+export interface SubPlanData {
+  date: string;
+  schedule: ScheduleEntry[];
+  pullOuts: { time: string; reason: string }[];
+  contacts: Record<string, string>;
+  procedures?: string;
+}
+
+function minToTime(min: number): string {
+  const h = String(Math.floor(min / 60)).padStart(2, '0');
+  const m = String(min % 60).padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+export async function buildSubPlanData(date: string): Promise<SubPlanData> {
+  const dayStart = new Date(date);
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const dayEnd = new Date(dayStart);
+  dayEnd.setUTCDate(dayStart.getUTCDate() + 1);
+
+  const [plan, events, blocks, prefs] = await Promise.all([
+    prisma.dailyPlan.findFirst({
+      where: { date: dayStart },
+      include: { items: { include: { activity: true } } },
+    }),
+    prisma.calendarEvent.findMany({
+      where: { start: { lte: dayEnd }, end: { gte: dayStart } },
+    }),
+    prisma.unavailableBlock.findMany({ where: { date: dayStart } }),
+    prisma.teacherPreferences.findFirst({ where: { id: 1 } }),
+  ]);
+
+  const schedule: ScheduleEntry[] = [];
+  plan?.items.forEach((i) =>
+    schedule.push({ time: minToTime(i.startMin), activity: i.activity?.title ?? '' }),
+  );
+  events.forEach((e) =>
+    schedule.push({
+      time: minToTime(new Date(e.start).getUTCHours() * 60 + new Date(e.start).getUTCMinutes()),
+      note: e.title,
+    }),
+  );
+  blocks
+    .filter((b) => b.blockType === 'TEACHER_ABSENCE')
+    .forEach((b) => schedule.push({ time: minToTime(b.startMin), note: b.reason }));
+
+  schedule.sort((a, b) => a.time.localeCompare(b.time));
+
+  const pullOuts = blocks
+    .filter((b) => b.blockType === 'STUDENT_PULL_OUT')
+    .map((b) => ({ time: minToTime(b.startMin), reason: b.reason }));
+
+  const contacts = prefs?.subPlanContacts as Prisma.JsonValue | null as
+    | Record<string, string>
+    | undefined;
+
+  return {
+    date: dayStart.toISOString().split('T')[0],
+    schedule,
+    pullOuts,
+    contacts: contacts || {},
+    procedures: prefs?.subPlanProcedures || undefined,
+  };
+}
+
+export async function generateSubPlan(date: string): Promise<Buffer> {
+  const data = await buildSubPlanData(date);
+  return generateSubPlanPDF({
+    today: data.schedule.map((s) => ({ time: s.time, activity: s.activity ?? s.note ?? '' })),
+    upcoming: [],
+    procedures: data.procedures || '',
+    studentNotes: pullOutsText(data.pullOuts),
+    emergencyContacts: formatContacts(data.contacts),
+  });
+}
+
+function pullOutsText(pullOuts: { time: string; reason: string }[]): string {
+  return pullOuts.map((p) => `${p.time} - ${p.reason}`).join('\n');
+}
+
+function formatContacts(c: Record<string, string>): string {
+  return Object.entries(c)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}

--- a/server/tests/subPlanService.test.ts
+++ b/server/tests/subPlanService.test.ts
@@ -1,0 +1,85 @@
+import { prisma } from '../src/prisma';
+import { generateSubPlan } from '../src/services/subPlanService';
+
+describe('sub plan service', () => {
+  beforeAll(async () => {
+    await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
+    await prisma.calendarEvent.deleteMany();
+    await prisma.unavailableBlock.deleteMany();
+    await prisma.dailyPlanItem.deleteMany();
+    await prisma.dailyPlan.deleteMany();
+    await prisma.weeklySchedule.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.teacherPreferences.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.calendarEvent.deleteMany();
+    await prisma.unavailableBlock.deleteMany();
+    await prisma.dailyPlanItem.deleteMany();
+    await prisma.dailyPlan.deleteMany();
+    await prisma.weeklySchedule.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.teacherPreferences.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  it('generates sub plan from stored data', async () => {
+    const subject = await prisma.subject.create({ data: { name: 'Math' } });
+    const milestone = await prisma.milestone.create({
+      data: { title: 'M', subjectId: subject.id },
+    });
+    const activity = await prisma.activity.create({
+      data: { title: 'Count to 20', milestoneId: milestone.id },
+    });
+    const lessonPlan = await prisma.lessonPlan.create({
+      data: {
+        weekStart: new Date('2025-06-15'),
+        schedule: { create: { day: 0, activityId: activity.id } },
+      },
+    });
+    await prisma.dailyPlan.create({
+      data: {
+        date: new Date('2025-06-15'),
+        lessonPlanId: lessonPlan.id,
+        items: { create: { startMin: 540, endMin: 600, activityId: activity.id } },
+      },
+    });
+    await prisma.calendarEvent.create({
+      data: {
+        title: 'Assembly',
+        start: new Date('2025-06-15T09:45:00.000Z'),
+        end: new Date('2025-06-15T10:30:00.000Z'),
+        allDay: false,
+        eventType: 'ASSEMBLY',
+        source: 'MANUAL',
+      },
+    });
+    await prisma.unavailableBlock.create({
+      data: {
+        date: new Date('2025-06-15'),
+        startMin: 660,
+        endMin: 690,
+        reason: 'Speech therapy',
+        blockType: 'STUDENT_PULL_OUT',
+      },
+    });
+    await prisma.teacherPreferences.create({
+      data: {
+        teachingStyles: '[]',
+        pacePreference: 'balanced',
+        prepTime: 30,
+        subPlanContacts: { principal: 'P', office: '555' },
+        subPlanProcedures: 'Lockdown routine',
+      },
+    });
+    const buf = await generateSubPlan('2025-06-15', 1);
+    expect(buf.length).toBeGreaterThan(0);
+  });
+});

--- a/server/tests/yearPlan.test.ts
+++ b/server/tests/yearPlan.test.ts
@@ -2,15 +2,22 @@ import request from 'supertest';
 import app from '../src/index';
 import { prisma } from '../src/prisma';
 
+let teacherId: number;
 beforeAll(async () => {
   await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
   await prisma.yearPlanEntry.deleteMany();
   await prisma.shareLink.deleteMany();
+  await prisma.user.deleteMany();
+  const t = await prisma.user.create({
+    data: { email: 'year@test.com', password: 'x', name: 'Y' },
+  });
+  teacherId = t.id;
 });
 
 afterAll(async () => {
   await prisma.yearPlanEntry.deleteMany();
   await prisma.shareLink.deleteMany();
+  await prisma.user.deleteMany();
   await prisma.$disconnect();
 });
 
@@ -18,21 +25,21 @@ describe('year plan routes', () => {
   it('returns entries for the year', async () => {
     await prisma.yearPlanEntry.create({
       data: {
-        teacherId: 1,
+        teacherId,
         entryType: 'UNIT',
         title: 'Numbers to 20',
         start: new Date('2025-01-06'),
         end: new Date('2025-01-31'),
       },
     });
-    const res = await request(app).get('/api/year-plan').query({ teacherId: 1, year: 2025 });
+    const res = await request(app).get('/api/year-plan').query({ teacherId, year: 2025 });
     expect(res.status).toBe(200);
     expect(res.body.length).toBe(1);
     expect(res.body[0].title).toBe('Numbers to 20');
   });
 
   it('creates share link', async () => {
-    const res = await request(app).post('/api/share/year-plan').send({ teacherId: 1, year: 2025 });
+    const res = await request(app).post('/api/share/year-plan').send({ teacherId, year: 2025 });
     expect(res.status).toBe(201);
     expect(res.body.shareToken).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- add SubPlanGenerator modal to client
- update emergency plan button to use modal
- allow saving contacts/procedures in preferences
- implement backend SubPlanService and new API endpoint
- add migration for new fields
- add unit tests for service and adjust existing tests

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68485a7c325c832d8cd248ad9e184d2a