### PR TITLE
Add milestone description and standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ teaching-engine2.0/
 └── docker-compose.yml    # Container orchestration
 ```
 
+### Database Schema (simplified)
+
+```prisma
+model Milestone {
+  id            Int      @id @default(autoincrement())
+  title         String
+  description   String?
+  standardCodes String   @default("[]")
+  subjectId     Int
+}
+```
+
 ## 🚀 Quick Start
 
 ### Prerequisites

--- a/client/src/__tests__/MilestoneList.test.tsx
+++ b/client/src/__tests__/MilestoneList.test.tsx
@@ -17,8 +17,8 @@ vi.mock('../api', async () => {
 describe('MilestoneList', () => {
   it('renders milestones with links', () => {
     const milestones: Milestone[] = [
-      { id: 1, title: 'M1', subjectId: 1, activities: [] },
-      { id: 2, title: 'M2', subjectId: 1, activities: [] },
+      { id: 1, title: 'M1', subjectId: 1, description: 'd1', standardCodes: [], activities: [] },
+      { id: 2, title: 'M2', subjectId: 1, description: 'd2', standardCodes: [], activities: [] },
     ];
 
     renderWithRouter(<MilestoneList milestones={milestones} subjectId={1} />);

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -23,6 +23,8 @@ export interface Milestone {
   id: number;
   title: string;
   subjectId: number;
+  description?: string | null;
+  standardCodes: string[];
   activities: Activity[];
 }
 
@@ -97,7 +99,12 @@ export const useCreateSubject = () => {
 export const useCreateMilestone = () => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { title: string; subjectId: number }) => api.post('/milestones', data),
+    mutationFn: (data: {
+      title: string;
+      subjectId: number;
+      description?: string;
+      standardCodes: string[];
+    }) => api.post('/milestones', data),
     onSuccess: (_res, vars) => {
       qc.invalidateQueries({ queryKey: ['subject', vars.subjectId] });
       toast.success('Milestone created');
@@ -175,8 +182,18 @@ export const useDeleteSubject = () => {
 export const useUpdateMilestone = () => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { id: number; title: string; subjectId: number }) =>
-      api.put(`/milestones/${data.id}`, { title: data.title }),
+    mutationFn: (data: {
+      id: number;
+      title: string;
+      subjectId: number;
+      description?: string;
+      standardCodes: string[];
+    }) =>
+      api.put(`/milestones/${data.id}`, {
+        title: data.title,
+        description: data.description,
+        standardCodes: data.standardCodes,
+      }),
     onSuccess: (_res, vars) => {
       qc.invalidateQueries({ queryKey: ['milestone', vars.id] });
       qc.invalidateQueries({ queryKey: ['subject', vars.subjectId] });

--- a/client/src/components/MilestoneList.tsx
+++ b/client/src/components/MilestoneList.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Milestone } from '../api';
 import { useCreateMilestone, useUpdateMilestone, useDeleteMilestone } from '../api';
 import Dialog from './Dialog';
+import StandardsTagInput from './StandardsTagInput';
 
 interface Props {
   milestones: Milestone[];
@@ -15,23 +16,37 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
   const remove = useDeleteMilestone();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [codes, setCodes] = useState<string[]>([]);
   const [editId, setEditId] = useState<number | null>(null);
   const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editCodes, setEditCodes] = useState<string[]>([]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
-    create.mutate({ title, subjectId });
+    create.mutate({ title, subjectId, description, standardCodes: codes });
     setTitle('');
+    setDescription('');
+    setCodes([]);
     setOpen(false);
   };
 
   const handleEditSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (editId === null || !editTitle.trim()) return;
-    update.mutate({ id: editId, title: editTitle, subjectId });
+    update.mutate({
+      id: editId,
+      title: editTitle,
+      subjectId,
+      description: editDescription,
+      standardCodes: editCodes,
+    });
     setEditId(null);
     setEditTitle('');
+    setEditDescription('');
+    setEditCodes([]);
   };
 
   return (
@@ -51,6 +66,16 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
               className="border p-2"
             />
           </label>
+          <label className="flex flex-col">
+            <span className="sr-only">Description</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Description"
+              className="border p-2"
+            />
+          </label>
+          <StandardsTagInput value={codes} onChange={setCodes} />
           <button type="submit" className="self-end px-2 py-1 bg-blue-600 text-white">
             Save
           </button>
@@ -70,6 +95,8 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
                     onClick={() => {
                       setEditId(m.id);
                       setEditTitle(m.title);
+                      setEditDescription(m.description ?? '');
+                      setEditCodes(m.standardCodes ?? []);
                     }}
                   >
                     Edit
@@ -82,6 +109,16 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
                   </button>
                 </div>
               </div>
+              {m.description && <p className="text-sm">{m.description}</p>}
+              {m.standardCodes?.length > 0 && (
+                <div className="flex flex-wrap gap-1 text-xs">
+                  {m.standardCodes.map((c) => (
+                    <span key={c} className="px-1 bg-gray-200 rounded">
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div className="h-2 bg-gray-200 rounded">
                 <div className="h-full bg-blue-500" style={{ width: `${progress}%` }} />
               </div>
@@ -100,6 +137,15 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
               className="border p-2"
             />
           </label>
+          <label className="flex flex-col">
+            <span className="sr-only">Edit description</span>
+            <textarea
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              className="border p-2"
+            />
+          </label>
+          <StandardsTagInput value={editCodes} onChange={setEditCodes} />
           <button type="submit" className="self-end px-2 py-1 bg-blue-600 text-white">
             Save
           </button>

--- a/client/src/components/StandardsTagInput.tsx
+++ b/client/src/components/StandardsTagInput.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+
+interface Props {
+  value: string[];
+  onChange: (v: string[]) => void;
+}
+
+export default function StandardsTagInput({ value, onChange }: Props) {
+  const [input, setInput] = useState('');
+  const add = () => {
+    const trimmed = input.trim();
+    if (trimmed && !value.includes(trimmed) && value.length < 10) {
+      onChange([...value, trimmed]);
+      setInput('');
+    }
+  };
+  return (
+    <div className="border p-2 rounded">
+      <div className="flex flex-wrap gap-1 mb-1">
+        {value.map((c) => (
+          <span key={c} className="px-1 bg-blue-200 rounded text-sm">
+            {c}
+            <button
+              type="button"
+              className="ml-1 text-red-600"
+              onClick={() => onChange(value.filter((v) => v !== c))}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            add();
+          }
+        }}
+        placeholder="Add code"
+        className="border p-1 w-full"
+      />
+    </div>
+  );
+}

--- a/client/src/pages/MilestoneDetailPage.tsx
+++ b/client/src/pages/MilestoneDetailPage.tsx
@@ -12,6 +12,16 @@ export default function MilestoneDetailPage() {
   return (
     <div>
       <h1>{data.title}</h1>
+      {data.description && <p className="mb-2">{data.description}</p>}
+      {data.standardCodes.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2 text-sm">
+          {data.standardCodes.map((c) => (
+            <span key={c} className="px-1 bg-gray-200 rounded">
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
       <ActivityList
         activities={data.activities}
         milestoneId={milestoneId}

--- a/packages/database/prisma/migrations/20250610173000_add_milestone_description/migration.sql
+++ b/packages/database/prisma/migrations/20250610173000_add_milestone_description/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Milestone" ADD COLUMN "description" TEXT;
+ALTER TABLE "Milestone" ADD COLUMN "standardCodes" TEXT NOT NULL DEFAULT '[]';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -32,6 +32,8 @@ model Milestone {
   estHours   Int?
   deadline   ReportDeadline? @relation(fields: [deadlineId], references: [id])
   deadlineId Int?
+  description String?
+  standardCodes String  @default("[]")
 }
 
 model Activity {

--- a/server/src/routes/milestone.ts
+++ b/server/src/routes/milestone.ts
@@ -5,12 +5,22 @@ import { validate, milestoneCreateSchema, milestoneUpdateSchema } from '../valid
 
 const router = Router();
 
-router.get('/', async (_req, res, next) => {
+router.get('/', async (req, res, next) => {
   try {
+    const where: Prisma.MilestoneWhereInput = {};
+    if (typeof req.query.standards === 'string') {
+      where.standardCodes = { contains: req.query.standards };
+    }
     const milestones = await prisma.milestone.findMany({
+      where,
       include: { activities: true },
     });
-    res.json(milestones);
+    res.json(
+      milestones.map((m) => ({
+        ...m,
+        standardCodes: JSON.parse(m.standardCodes),
+      })),
+    );
   } catch (err) {
     next(err);
   }
@@ -23,7 +33,10 @@ router.get('/:id', async (req, res, next) => {
       include: { activities: true },
     });
     if (!milestone) return res.status(404).json({ error: 'Not Found' });
-    res.json(milestone);
+    res.json({
+      ...milestone,
+      standardCodes: JSON.parse(milestone.standardCodes),
+    });
   } catch (err) {
     next(err);
   }
@@ -37,9 +50,14 @@ router.post('/', validate(milestoneCreateSchema), async (req, res, next) => {
         subjectId: req.body.subjectId,
         targetDate: req.body.targetDate ? new Date(req.body.targetDate) : undefined,
         estHours: req.body.estHours,
+        description: req.body.description,
+        standardCodes: JSON.stringify(req.body.standardCodes ?? []),
       },
     });
-    res.status(201).json(milestone);
+    res.status(201).json({
+      ...milestone,
+      standardCodes: JSON.parse(milestone.standardCodes),
+    });
   } catch (err) {
     next(err);
   }
@@ -53,9 +71,14 @@ router.put('/:id', validate(milestoneUpdateSchema), async (req, res, next) => {
         title: req.body.title,
         targetDate: req.body.targetDate ? new Date(req.body.targetDate) : undefined,
         estHours: req.body.estHours,
+        description: req.body.description,
+        standardCodes: JSON.stringify(req.body.standardCodes ?? []),
       },
     });
-    res.json(milestone);
+    res.json({
+      ...milestone,
+      standardCodes: JSON.parse(milestone.standardCodes),
+    });
   } catch (err) {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
       return res.status(404).json({ error: 'Not Found' });

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -11,6 +11,8 @@ export const milestoneCreateSchema = z.object({
   subjectId: z.number(),
   targetDate: z.string().datetime().optional(),
   estHours: z.number().int().optional(),
+  description: z.string().max(10000).optional(),
+  standardCodes: z.array(z.string()).max(10).optional(),
 });
 
 export const milestoneUpdateSchema = milestoneCreateSchema.omit({ subjectId: true });

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -90,6 +90,19 @@ describe('Milestone API', () => {
     expect(get.body.title).toBe('MS');
   });
 
+  it('accepts long description and codes', async () => {
+    const desc = 'a'.repeat(10000);
+    const codes = ['C1', 'C2'];
+    const create = await request(app)
+      .post('/api/milestones')
+      .send({ title: 'Rich', subjectId, description: desc, standardCodes: codes });
+    expect(create.status).toBe(201);
+    const get = await request(app).get(`/api/milestones/${create.body.id}`);
+    expect(get.status).toBe(200);
+    expect(get.body.description).toBe(desc);
+    expect(get.body.standardCodes).toEqual(codes);
+  });
+
   it('rejects invalid milestone data', async () => {
     const res = await request(app).post('/api/milestones').send({ title: '' });
     expect(res.status).toBe(400);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -14,10 +14,18 @@ test('create subject, milestone and activity', async ({ page }) => {
   // open milestone dialog
   await page.click('text=Add Milestone');
   await page.fill('input[placeholder="New milestone"]', 'M1');
+  await page.fill('textarea[placeholder="Description"]', 'desc');
+  await page.fill('input[placeholder="Add code"]', 'ELA1.4');
+  await page.keyboard.press('Enter');
+  await page.fill('input[placeholder="Add code"]', 'MATH1.2');
+  await page.keyboard.press('Enter');
   await page.click('button:has-text("Save")');
 
   // navigate to the milestone detail page
   await page.click('text=M1');
+
+  await expect(page.locator('text=ELA1.4')).toBeVisible();
+  await expect(page.locator('text=MATH1.2')).toBeVisible();
 
   // open activity dialog
   await page.click('text=Add Activity');


### PR DESCRIPTION
## Summary
- add new milestone fields `description` and `standardCodes`
- support standards filter and parsing in milestone routes
- update validation, migration and API types
- extend UI forms with description textarea and standards tag input
- update tests and docs

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848622fb534832daed4b0ee98cb831d