### PR TITLE
Add milestone descriptions and standards

### DIFF
--- a/client/src/__tests__/MilestoneList.test.tsx
+++ b/client/src/__tests__/MilestoneList.test.tsx
@@ -17,8 +17,8 @@ vi.mock('../api', async () => {
 describe('MilestoneList', () => {
   it('renders milestones with links', () => {
     const milestones: Milestone[] = [
-      { id: 1, title: 'M1', subjectId: 1, activities: [] },
-      { id: 2, title: 'M2', subjectId: 1, activities: [] },
+      { id: 1, title: 'M1', subjectId: 1, activities: [], description: 'd1', standardCodes: ['A'] },
+      { id: 2, title: 'M2', subjectId: 1, activities: [], description: 'd2', standardCodes: ['B'] },
     ];
 
     renderWithRouter(<MilestoneList milestones={milestones} subjectId={1} />);

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -23,6 +23,8 @@ export interface Milestone {
   id: number;
   title: string;
   subjectId: number;
+  description?: string | null;
+  standardCodes: string[];
   activities: Activity[];
 }
 
@@ -97,7 +99,12 @@ export const useCreateSubject = () => {
 export const useCreateMilestone = () => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { title: string; subjectId: number }) => api.post('/milestones', data),
+    mutationFn: (data: {
+      title: string;
+      subjectId: number;
+      description?: string;
+      standardCodes?: string[];
+    }) => api.post('/milestones', data),
     onSuccess: (_res, vars) => {
       qc.invalidateQueries({ queryKey: ['subject', vars.subjectId] });
       toast.success('Milestone created');
@@ -175,8 +182,18 @@ export const useDeleteSubject = () => {
 export const useUpdateMilestone = () => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { id: number; title: string; subjectId: number }) =>
-      api.put(`/milestones/${data.id}`, { title: data.title }),
+    mutationFn: (data: {
+      id: number;
+      title: string;
+      subjectId: number;
+      description?: string;
+      standardCodes?: string[];
+    }) =>
+      api.put(`/milestones/${data.id}`, {
+        title: data.title,
+        description: data.description,
+        standardCodes: data.standardCodes,
+      }),
     onSuccess: (_res, vars) => {
       qc.invalidateQueries({ queryKey: ['milestone', vars.id] });
       qc.invalidateQueries({ queryKey: ['subject', vars.subjectId] });

--- a/client/src/components/MilestoneList.tsx
+++ b/client/src/components/MilestoneList.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Milestone } from '../api';
 import { useCreateMilestone, useUpdateMilestone, useDeleteMilestone } from '../api';
 import Dialog from './Dialog';
+import TagInput from './TagInput';
 
 interface Props {
   milestones: Milestone[];
@@ -15,23 +16,37 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
   const remove = useDeleteMilestone();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [codes, setCodes] = useState<string[]>([]);
   const [editId, setEditId] = useState<number | null>(null);
   const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editCodes, setEditCodes] = useState<string[]>([]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
-    create.mutate({ title, subjectId });
+    create.mutate({ title, subjectId, description, standardCodes: codes });
     setTitle('');
+    setDescription('');
+    setCodes([]);
     setOpen(false);
   };
 
   const handleEditSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (editId === null || !editTitle.trim()) return;
-    update.mutate({ id: editId, title: editTitle, subjectId });
+    update.mutate({
+      id: editId,
+      title: editTitle,
+      subjectId,
+      description: editDescription,
+      standardCodes: editCodes,
+    });
     setEditId(null);
     setEditTitle('');
+    setEditDescription('');
+    setEditCodes([]);
   };
 
   return (
@@ -51,6 +66,16 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
               className="border p-2"
             />
           </label>
+          <label className="flex flex-col">
+            <span className="sr-only">Description</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Description"
+              className="border p-2"
+            />
+          </label>
+          <TagInput tags={codes} onChange={setCodes} placeholder="Add standard code" />
           <button type="submit" className="self-end px-2 py-1 bg-blue-600 text-white">
             Save
           </button>
@@ -70,6 +95,8 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
                     onClick={() => {
                       setEditId(m.id);
                       setEditTitle(m.title);
+                      setEditDescription(m.description ?? '');
+                      setEditCodes(m.standardCodes ?? []);
                     }}
                   >
                     Edit
@@ -82,6 +109,16 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
                   </button>
                 </div>
               </div>
+              {m.description && <p className="italic text-sm">{m.description}</p>}
+              {m.standardCodes && m.standardCodes.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {m.standardCodes.map((c) => (
+                    <span key={c} className="bg-gray-200 px-1 text-xs">
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div className="h-2 bg-gray-200 rounded">
                 <div className="h-full bg-blue-500" style={{ width: `${progress}%` }} />
               </div>
@@ -100,6 +137,16 @@ export default function MilestoneList({ milestones, subjectId }: Props) {
               className="border p-2"
             />
           </label>
+          <label className="flex flex-col">
+            <span className="sr-only">Edit description</span>
+            <textarea
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              className="border p-2"
+              placeholder="Description"
+            />
+          </label>
+          <TagInput tags={editCodes} onChange={setEditCodes} placeholder="Add standard code" />
           <button type="submit" className="self-end px-2 py-1 bg-blue-600 text-white">
             Save
           </button>

--- a/client/src/components/TagInput.tsx
+++ b/client/src/components/TagInput.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+interface Props {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+}
+
+export default function TagInput({ tags, onChange, placeholder }: Props) {
+  const [input, setInput] = useState('');
+
+  const addTag = () => {
+    const val = input.trim();
+    if (val && !tags.includes(val)) {
+      onChange([...tags, val]);
+    }
+    setInput('');
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-1">
+        {tags.map((t) => (
+          <span key={t} className="px-1 bg-gray-200 text-sm flex items-center gap-1">
+            {t}
+            <button
+              type="button"
+              onClick={() => onChange(tags.filter((c) => c !== t))}
+              aria-label={`Remove ${t}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <input
+        className="border p-1 mt-1"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            addTag();
+          }
+        }}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/client/src/pages/MilestoneDetailPage.tsx
+++ b/client/src/pages/MilestoneDetailPage.tsx
@@ -12,6 +12,16 @@ export default function MilestoneDetailPage() {
   return (
     <div>
       <h1>{data.title}</h1>
+      {data.description && <p className="italic mb-2">{data.description}</p>}
+      {data.standardCodes && data.standardCodes.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {data.standardCodes.map((c) => (
+            <span key={c} className="bg-gray-200 px-1 text-xs">
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
       <ActivityList
         activities={data.activities}
         milestoneId={milestoneId}

--- a/packages/database/prisma/migrations/20250610220455_add_milestone_fields/migration.sql
+++ b/packages/database/prisma/migrations/20250610220455_add_milestone_fields/migration.sql
@@ -1,0 +1,22 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Milestone" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "subjectId" INTEGER NOT NULL,
+    "userId" INTEGER,
+    "description" TEXT,
+    "standardCodes" JSONB NOT NULL DEFAULT [],
+    "targetDate" DATETIME,
+    "estHours" INTEGER,
+    "deadlineId" INTEGER,
+    CONSTRAINT "Milestone_subjectId_fkey" FOREIGN KEY ("subjectId") REFERENCES "Subject" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Milestone_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Milestone_deadlineId_fkey" FOREIGN KEY ("deadlineId") REFERENCES "ReportDeadline" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Milestone" ("deadlineId", "estHours", "id", "subjectId", "targetDate", "title", "userId") SELECT "deadlineId", "estHours", "id", "subjectId", "targetDate", "title", "userId" FROM "Milestone";
+DROP TABLE "Milestone";
+ALTER TABLE "new_Milestone" RENAME TO "Milestone";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -28,6 +28,9 @@ model Milestone {
   activities Activity[]
   userId     Int?
   user       User?     @relation(fields: [userId], references: [id])
+  description String?
+  /// Array of curriculum standard codes associated with the milestone
+  standardCodes Json    @default("[]")
   targetDate DateTime?
   estHours   Int?
   deadline   ReportDeadline? @relation(fields: [deadlineId], references: [id])

--- a/server/src/routes/milestone.ts
+++ b/server/src/routes/milestone.ts
@@ -37,6 +37,8 @@ router.post('/', validate(milestoneCreateSchema), async (req, res, next) => {
         subjectId: req.body.subjectId,
         targetDate: req.body.targetDate ? new Date(req.body.targetDate) : undefined,
         estHours: req.body.estHours,
+        description: req.body.description,
+        standardCodes: req.body.standardCodes,
       },
     });
     res.status(201).json(milestone);
@@ -53,6 +55,8 @@ router.put('/:id', validate(milestoneUpdateSchema), async (req, res, next) => {
         title: req.body.title,
         targetDate: req.body.targetDate ? new Date(req.body.targetDate) : undefined,
         estHours: req.body.estHours,
+        description: req.body.description,
+        standardCodes: req.body.standardCodes,
       },
     });
     res.json(milestone);

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -11,6 +11,8 @@ export const milestoneCreateSchema = z.object({
   subjectId: z.number(),
   targetDate: z.string().datetime().optional(),
   estHours: z.number().int().optional(),
+  description: z.string().max(10000).optional(),
+  standardCodes: z.array(z.string().min(1).max(50)).max(10).optional().default([]),
 });
 
 export const milestoneUpdateSchema = milestoneCreateSchema.omit({ subjectId: true });

--- a/server/tests/api.test.ts
+++ b/server/tests/api.test.ts
@@ -90,6 +90,22 @@ describe('Milestone API', () => {
     expect(get.body.title).toBe('MS');
   });
 
+  it('creates milestone with description and codes', async () => {
+    const create = await request(app)
+      .post('/api/milestones')
+      .send({
+        title: 'MS2',
+        subjectId,
+        description: 'desc',
+        standardCodes: ['A', 'B'],
+      });
+    expect(create.status).toBe(201);
+    const id = create.body.id;
+    const get = await request(app).get(`/api/milestones/${id}`);
+    expect(get.body.description).toBe('desc');
+    expect(get.body.standardCodes).toEqual(['A', 'B']);
+  });
+
   it('rejects invalid milestone data', async () => {
     const res = await request(app).post('/api/milestones').send({ title: '' });
     expect(res.status).toBe(400);


### PR DESCRIPTION
## Summary
- support optional description and standard codes on milestones
- migrate database and regenerate Prisma client
- validate fields with Zod
- expose fields via milestone routes
- update React API types and milestone UI
- show description and codes in milestone detail and list
- add tag input component
- test new behaviour in API and React tests

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6848ab03f5ec832db68313b0aa168ef3