### PR TITLE
Add holiday support in weekly planner

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import TimetablePage from './pages/TimetablePage';
 import YearAtAGlancePage from './pages/YearAtAGlancePage';
 import DashboardPage from './pages/DashboardPage';
 import NotesPage from './pages/NotesPage';
+import SettingsPage from './pages/SettingsPage';
 import { NotificationProvider } from './contexts/NotificationContext';
 
 export default function App() {
@@ -29,6 +30,7 @@ export default function App() {
         <Route path="/notifications" element={<NotificationsPage />} />
         <Route path="/newsletters/new" element={<NewsletterEditor />} />
         <Route path="/newsletters/draft" element={<NewsletterDraftViewer />} />
+        <Route path="/settings" element={<SettingsPage />} />
       </Routes>
     </NotificationProvider>
   );

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -625,3 +625,31 @@ export const fetchSubPlan = (date: string) =>
     params: { date },
     responseType: 'blob',
   });
+
+export interface Holiday {
+  id: number;
+  date: string;
+  name: string;
+}
+
+export const useHolidays = () =>
+  useQuery<Holiday[]>({
+    queryKey: ['holidays'],
+    queryFn: async () => (await api.get('/holidays')).data,
+  });
+
+export const useAddHoliday = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: Omit<Holiday, 'id'>) => api.post('/holidays', data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['holidays'] }),
+  });
+};
+
+export const useDeleteHoliday = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => api.delete(`/holidays/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['holidays'] }),
+  });
+};

--- a/client/src/components/WeekCalendarGrid.tsx
+++ b/client/src/components/WeekCalendarGrid.tsx
@@ -1,4 +1,4 @@
-import type { WeeklyScheduleItem, Activity, TimetableSlot, CalendarEvent } from '../api';
+import type { WeeklyScheduleItem, Activity, TimetableSlot, CalendarEvent, Holiday } from '../api';
 import { useDroppable } from '@dnd-kit/core';
 
 interface Props {
@@ -6,6 +6,7 @@ interface Props {
   activities: Record<number, Activity>;
   timetable?: TimetableSlot[];
   events?: CalendarEvent[];
+  holidays?: Holiday[];
   invalidDay?: number;
 }
 
@@ -14,6 +15,7 @@ export default function WeekCalendarGrid({
   activities,
   timetable,
   events,
+  holidays,
   invalidDay,
 }: Props) {
   const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
@@ -27,6 +29,8 @@ export default function WeekCalendarGrid({
         const blocked = daySlot && !daySlot.subjectId;
         const label = daySlot?.subject?.name ?? (blocked ? 'Prep' : '');
         const dayEvents = events?.filter((e) => new Date(e.start).getUTCDay() === (idx + 1) % 7);
+        const dayHolidays = holidays?.filter((h) => (new Date(h.date).getUTCDay() + 6) % 7 === idx);
+        const isHoliday = dayHolidays && dayHolidays.length > 0;
         const { isOver, setNodeRef } = useDroppable({
           id: `day-${idx}`,
           data: { day: idx },
@@ -37,10 +41,17 @@ export default function WeekCalendarGrid({
             key={idx}
             ref={setNodeRef}
             data-testid={`day-${idx}`}
-            className={`min-h-24 border flex flex-col items-center justify-start bg-gray-50 p-1${blocked ? ' opacity-50 pointer-events-none' : ''}${isOver ? ' bg-blue-100' : ''}${invalid ? ' border-red-500' : ''}`}
+            className={`min-h-24 border flex flex-col items-center justify-start bg-gray-50 p-1${
+              blocked || isHoliday ? ' opacity-50 pointer-events-none' : ''
+            }${isOver ? ' bg-blue-100' : ''}${invalid ? ' border-red-500' : ''}`}
           >
             <span>{d}</span>
             {label && <div className="text-xs">{label}</div>}
+            {dayHolidays?.map((h) => (
+              <div key={h.id} className="text-xs bg-yellow-200 w-full mt-1">
+                {h.name}
+              </div>
+            ))}
             {invalid && (
               <div className="text-xs text-red-600" data-testid="slot-warning">
                 Too long for this slot

--- a/client/src/components/settings/HolidaySettings.tsx
+++ b/client/src/components/settings/HolidaySettings.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useHolidays, useAddHoliday, useDeleteHoliday } from '../../api';
+
+export default function HolidaySettings() {
+  const { data: holidays } = useHolidays();
+  const add = useAddHoliday();
+  const remove = useDeleteHoliday();
+  const [date, setDate] = useState('');
+  const [name, setName] = useState('');
+
+  const handleAdd = () => {
+    if (!date || !name.trim()) return;
+    add.mutate({ date: `${date}T00:00:00.000Z`, name });
+    setDate('');
+    setName('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2 items-center">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="border p-1"
+        />
+        <input
+          type="text"
+          placeholder="Holiday name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-1"
+        />
+        <button className="px-2 py-1 bg-blue-600 text-white" onClick={handleAdd}>
+          Add
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {holidays?.map((h) => (
+          <li key={h.id} className="flex gap-2 items-center">
+            <span>
+              {h.date.split('T')[0]} - {h.name}
+            </span>
+            <button
+              className="px-1 text-sm bg-red-600 text-white"
+              onClick={() => remove.mutate(h.id)}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,0 +1,10 @@
+import HolidaySettings from '../components/settings/HolidaySettings';
+
+export default function SettingsPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl">Settings</h1>
+      <HolidaySettings />
+    </div>
+  );
+}

--- a/client/src/pages/WeeklyPlannerPage.tsx
+++ b/client/src/pages/WeeklyPlannerPage.tsx
@@ -8,6 +8,7 @@ import {
   useTimetable,
   useCalendarEvents,
   usePlannerSuggestions,
+  useHolidays,
 } from '../api';
 import ActivitySuggestionList from '../components/ActivitySuggestionList';
 import WeekCalendarGrid from '../components/WeekCalendarGrid';
@@ -30,7 +31,17 @@ export default function WeeklyPlannerPage() {
     weekStart,
     new Date(new Date(weekStart).getTime() + 6 * 86400000).toISOString(),
   );
+  const { data: holidays } = useHolidays();
   const { data: suggestions } = usePlannerSuggestions(weekStart, filters);
+  const weekHolidays = useMemo(() => {
+    if (!holidays) return [];
+    const start = new Date(weekStart);
+    const end = new Date(start.getTime() + 6 * 86400000);
+    return holidays.filter((h) => {
+      const d = new Date(h.date);
+      return d >= start && d <= end;
+    });
+  }, [holidays, weekStart]);
   const activities = useMemo(() => {
     const all: Record<number, Activity> = {};
     subjects.forEach((s) =>
@@ -118,6 +129,7 @@ export default function WeeklyPlannerPage() {
           activities={activities}
           timetable={timetable}
           events={events}
+          holidays={weekHolidays}
           invalidDay={invalidDay}
         />
         {!plan && (

--- a/client/tests/WeeklyPlanner.test.tsx
+++ b/client/tests/WeeklyPlanner.test.tsx
@@ -75,6 +75,7 @@ vi.mock('../src/api', async () => {
     useGeneratePlan: () => generateState,
     useMaterialDetails: () => ({ data: [] }),
     useCalendarEvents: () => ({ data: [] }),
+    useHolidays: () => ({ data: [] }),
     downloadPrintables: vi.fn(),
   };
 });

--- a/packages/database/prisma/migrations/20250611003530_add_holidays/migration.sql
+++ b/packages/database/prisma/migrations/20250611003530_add_holidays/migration.sql
@@ -1,0 +1,6 @@
+-- CreateTable
+CREATE TABLE "Holiday" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "date" DATETIME NOT NULL,
+    "name" TEXT NOT NULL
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -316,3 +316,9 @@ model EquipmentBooking {
   createdAt     DateTime               @default(now())
   updatedAt     DateTime               @updatedAt
 }
+
+model Holiday {
+  id   Int      @id @default(autoincrement())
+  date DateTime
+  name String
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,7 @@ import reportDeadlineRoutes from './routes/reportDeadline';
 import yearPlanRoutes from './routes/yearPlan';
 import shareRoutes from './routes/share';
 import equipmentBookingRoutes from './routes/equipmentBooking';
+import holidayRoutes from './routes/holiday';
 import { scheduleProgressCheck } from './jobs/progressCheck';
 import { scheduleUnreadNotificationEmails } from './jobs/unreadNotificationEmail';
 import { scheduleNewsletterTriggers } from './jobs/newsletterTrigger';
@@ -67,6 +68,7 @@ app.use('/api/report-deadlines', reportDeadlineRoutes);
 app.use('/api/year-plan', yearPlanRoutes);
 app.use('/api/share', shareRoutes);
 app.use('/api/equipment-bookings', equipmentBookingRoutes);
+app.use('/api/holidays', holidayRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/server/src/routes/holiday.ts
+++ b/server/src/routes/holiday.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import { prisma } from '../prisma';
+import { z } from 'zod';
+import { validate } from '../validation';
+
+const router = Router();
+
+const holidaySchema = z.object({
+  date: z.string().datetime(),
+  name: z.string().min(1),
+});
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const holidays = await prisma.holiday.findMany({ orderBy: { date: 'asc' } });
+    res.json(holidays);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(holidaySchema), async (req, res, next) => {
+  try {
+    const data = req.body as z.infer<typeof holidaySchema>;
+    const holiday = await prisma.holiday.create({
+      data: { date: new Date(data.date), name: data.name },
+    });
+    res.status(201).json(holiday);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await prisma.holiday.delete({ where: { id: Number(req.params.id) } });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -38,7 +38,10 @@ router.post('/generate', async (req, res, next) => {
         date: { gte: startDate, lte: endDate },
       },
     });
-    const availableBlocks = filterAvailableBlocksByCalendar(slots, events, unavail);
+    const holidays = await prisma.holiday.findMany({
+      where: { date: { gte: startDate, lte: endDate } },
+    });
+    const availableBlocks = filterAvailableBlocksByCalendar(slots, events, unavail, holidays);
     const urg = await getMilestoneUrgency();
     const priorityMap = new Map(urg.map((u) => [u.id, u.urgency]));
     const scheduleData = await generateWeeklySchedule({

--- a/server/src/services/planningEngine.ts
+++ b/server/src/services/planningEngine.ts
@@ -4,6 +4,7 @@ import type {
   TimetableSlot,
   CalendarEvent,
   UnavailableBlock,
+  Holiday,
 } from '@teaching-engine/database';
 
 export interface ScheduleItem {
@@ -31,9 +32,13 @@ export function filterAvailableBlocksByCalendar(
   slots: TimetableSlot[],
   events: CalendarEvent[],
   unavailable: UnavailableBlock[] = [],
+  holidays: Holiday[] = [],
 ): DailyBlock[] {
   return slots
     .filter((s) => s.subjectId)
+    .filter((slot) => {
+      return !holidays.some((h) => (new Date(h.date).getUTCDay() + 6) % 7 === slot.day);
+    })
     .filter((slot) => {
       const dayEvents = events.filter((e) => (new Date(e.start).getUTCDay() + 6) % 7 === slot.day);
       return dayEvents.every((ev) => {

--- a/server/tests/holiday.test.ts
+++ b/server/tests/holiday.test.ts
@@ -1,0 +1,29 @@
+import request from 'supertest';
+import app from '../src/index';
+import { prisma } from '../src/prisma';
+
+describe('Holiday API', () => {
+  afterAll(async () => {
+    await prisma.holiday.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  it('creates and lists holidays', async () => {
+    const create = await request(app)
+      .post('/api/holidays')
+      .send({ date: '2025-12-25T00:00:00.000Z', name: 'Christmas' });
+    expect(create.status).toBe(201);
+    const list = await request(app).get('/api/holidays');
+    expect(list.status).toBe(200);
+    expect(list.body.length).toBeGreaterThan(0);
+  });
+
+  it('deletes holiday', async () => {
+    const res = await request(app)
+      .post('/api/holidays')
+      .send({ date: '2025-01-01T00:00:00.000Z', name: 'NY' });
+    const id = res.body.id as number;
+    const del = await request(app).delete(`/api/holidays/${id}`);
+    expect(del.status).toBe(204);
+  });
+});

--- a/tests/e2e/holiday-planner.spec.ts
+++ b/tests/e2e/holiday-planner.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure planner skips holidays when auto-filling
+
+test('planner skips holiday dates', async ({ page }) => {
+  const ts = Date.now();
+  const subRes = await page.request.post('/api/subjects', { data: { name: `H${ts}` } });
+  const subjectId = (await subRes.json()).id as number;
+  const msRes = await page.request.post('/api/milestones', { data: { title: 'HM', subjectId } });
+  const milestoneId = (await msRes.json()).id as number;
+  await page.request.post('/api/activities', { data: { title: 'HA', milestoneId } });
+  await page.request.put('/api/timetable', {
+    data: [{ day: 3, startMin: 540, endMin: 600, subjectId }],
+  });
+
+  await page.goto('/settings');
+  await page.fill('input[type="date"]', '2025-12-25');
+  await page.fill('input[placeholder="Holiday name"]', 'Christmas');
+  await page.click('button:has-text("Add")');
+  await expect(page.locator('text=Christmas')).toBeVisible();
+
+  await page.goto('/planner');
+  await page.fill('input[type="date"]', '2025-12-22');
+  await page.click('text=Auto Fill');
+  await expect(page.getByText('Christmas')).toBeVisible();
+  await expect(page.locator('[data-testid="day-3"] >> text=HA')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- create `Holiday` model and migration
- add CRUD API for holidays
- integrate holiday blocking into planning engine
- add holiday settings UI and planner display
- update weekly planner to load holidays
- test holiday API and planner behavior

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848ce6b6a5c832d823cf9477555ca9f