### PR TITLE
Implement N-01 note prompt after activity completion

### DIFF
--- a/client/src/__tests__/ActivityList.test.tsx
+++ b/client/src/__tests__/ActivityList.test.tsx
@@ -27,7 +27,7 @@ describe('ActivityList', () => {
     expect(screen.getByText('A2')).toBeInTheDocument();
   });
 
-  it('associates each checkbox with a label', () => {
+  it('shows complete buttons', () => {
     const activities: Activity[] = [
       { id: 1, title: 'A1', milestoneId: 1, completedAt: null },
       { id: 2, title: 'A2', milestoneId: 1, completedAt: null },
@@ -35,11 +35,6 @@ describe('ActivityList', () => {
 
     renderWithRouter(<ActivityList activities={activities} milestoneId={1} />);
 
-    activities.forEach((a) => {
-      const labelText = `Mark ${a.title} complete`;
-      const checkbox = screen.getByLabelText(labelText) as HTMLInputElement;
-      expect(checkbox).toBeInTheDocument();
-      expect(checkbox.type).toBe('checkbox');
-    });
+    expect(screen.getAllByText('Mark Complete').length).toBe(2);
   });
 });

--- a/client/src/components/ActivityList.tsx
+++ b/client/src/components/ActivityList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import MaterialsInput from './activity/MaterialsInput';
 import type { Activity } from '../api';
+import CompleteActivityButton from './CompleteActivityButton';
 import {
   useCreateActivity,
   useUpdateActivity,
@@ -27,12 +28,12 @@ function SortableActivity({
   activity,
   onEdit,
   onDelete,
-  onToggle,
+  milestoneId,
 }: {
   activity: Activity;
   onEdit: () => void;
   onDelete: () => void;
-  onToggle: (checked: boolean) => void;
+  milestoneId: number;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: activity.id,
@@ -42,19 +43,10 @@ function SortableActivity({
     transition,
   };
   const progress = activity.completedAt ? 100 : 0;
-  const checkboxId = `activity-${activity.id}`;
   return (
     <li ref={setNodeRef} style={style} className="border p-2 rounded space-y-1">
       <div className="flex items-center gap-2" {...attributes} {...listeners}>
-        <input
-          id={checkboxId}
-          type="checkbox"
-          checked={!!activity.completedAt}
-          onChange={(e) => onToggle(e.target.checked)}
-        />
-        <label htmlFor={checkboxId} className="sr-only">
-          Mark {activity.title} complete
-        </label>
+        <CompleteActivityButton activity={activity} milestoneId={milestoneId} />
         <span className="flex-1">{activity.title}</span>
         <div className="flex gap-1">
           <button className="px-1 text-sm bg-gray-200" onClick={onEdit}>
@@ -161,14 +153,7 @@ export default function ActivityList({ activities, milestoneId, subjectId }: Pro
                     setEditTitle(a.title);
                   }}
                   onDelete={() => remove.mutate({ id: a.id, milestoneId, subjectId })}
-                  onToggle={(checked) =>
-                    update.mutate({
-                      id: a.id,
-                      milestoneId,
-                      subjectId,
-                      completedAt: checked ? new Date().toISOString() : null,
-                    })
-                  }
+                  milestoneId={milestoneId}
                 />
               );
             })}

--- a/client/src/components/CompleteActivityButton.tsx
+++ b/client/src/components/CompleteActivityButton.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Activity, useCompleteActivity } from '../api';
+import NoteModal from './NoteModal';
+
+export default function CompleteActivityButton({
+  activity,
+  milestoneId,
+}: {
+  activity: Activity;
+  milestoneId: number;
+}) {
+  const [showNoteModal, setShowNoteModal] = useState(false);
+  const complete = useCompleteActivity();
+
+  const handleClick = () => {
+    complete.mutate(
+      { id: activity.id, completed: !activity.completedAt, milestoneId, interactive: true },
+      {
+        onSuccess: (res) => {
+          if (res.showNotePrompt) setShowNoteModal(true);
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <button
+        className="px-1 text-sm bg-green-600 text-white"
+        onClick={handleClick}
+        disabled={complete.isPending}
+      >
+        {activity.completedAt ? 'Undo Complete' : 'Mark Complete'}
+      </button>
+      {showNoteModal && (
+        <NoteModal
+          activityId={activity.id}
+          milestoneId={milestoneId}
+          onClose={() => setShowNoteModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/client/src/components/DailyNotesEditor.tsx
+++ b/client/src/components/DailyNotesEditor.tsx
@@ -12,7 +12,7 @@ export default function DailyNotesEditor({
   const addNote = useAddNote();
 
   const handleSave = () => {
-    addNote.mutate({ content, public: false, activityId, dailyPlanId });
+    addNote.mutate({ content, type: 'private', activityId, dailyPlanId });
     setContent('');
   };
 

--- a/client/src/components/NoteModal.tsx
+++ b/client/src/components/NoteModal.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import Dialog from './Dialog';
+import { useAddNote } from '../api';
+
+export default function NoteModal({
+  activityId,
+  milestoneId,
+  onClose,
+}: {
+  activityId: number;
+  milestoneId?: number;
+  onClose: () => void;
+}) {
+  const [tab, setTab] = useState<'private' | 'public'>('private');
+  const [content, setContent] = useState('');
+  const addNote = useAddNote();
+
+  const handleSave = () => {
+    addNote.mutate({ activityId, milestoneId, content, type: tab }, { onSuccess: onClose });
+  };
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <button
+            className={`px-2 py-1 ${tab === 'private' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+            onClick={() => setTab('private')}
+          >
+            Private
+          </button>
+          <button
+            className={`px-2 py-1 ${tab === 'public' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+            onClick={() => setTab('public')}
+          >
+            Public
+          </button>
+        </div>
+        <textarea
+          className="border p-2 w-full"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button
+          className="px-2 py-1 bg-blue-600 text-white"
+          onClick={handleSave}
+          disabled={addNote.isPending}
+        >
+          Save
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -104,6 +104,25 @@ router.put('/:id', validate(activityUpdateSchema), async (req, res, next) => {
   }
 });
 
+router.patch('/:id/complete', async (req, res, next) => {
+  const { completed = true, interactive = false } = req.body as {
+    completed?: boolean;
+    interactive?: boolean;
+  };
+  try {
+    const activity = await prisma.activity.update({
+      where: { id: Number(req.params.id) },
+      data: { completedAt: completed ? new Date() : null },
+    });
+    res.json({ activity, showNotePrompt: interactive });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025') {
+      return res.status(404).json({ error: 'Not Found' });
+    }
+    next(err);
+  }
+});
+
 router.delete('/:id', async (req, res, next) => {
   try {
     await prisma.activity.delete({ where: { id: Number(req.params.id) } });

--- a/server/src/routes/note.ts
+++ b/server/src/routes/note.ts
@@ -27,11 +27,13 @@ router.post('/', async (req, res, next) => {
   try {
     const {
       content,
+      type,
       public: isPublic,
       activityId,
       dailyPlanId,
     } = req.body as {
       content: string;
+      type?: 'private' | 'public';
       public?: boolean;
       activityId?: number;
       dailyPlanId?: number;
@@ -39,7 +41,7 @@ router.post('/', async (req, res, next) => {
     const note = await prisma.note.create({
       data: {
         content,
-        public: isPublic ?? false,
+        public: type ? type === 'public' : (isPublic ?? false),
         activityId: activityId ?? undefined,
         dailyPlanId: dailyPlanId ?? undefined,
       },


### PR DESCRIPTION
## Summary
- add `/activities/:id/complete` endpoint that can return a note prompt flag
- allow POST `/api/notes` to accept `{activityId, content, type}`
- expose `useCompleteActivity` and enhance `useAddNote` API
- add `NoteModal` and `CompleteActivityButton` components
- show note modal after completing an activity
- update ActivityList to use the new button
- adjust DailyNotesEditor and tests

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848dd90ea9c832d8e7901cc43f0b4cf