### PR TITLE
Implement fallback activities for sub plans

### DIFF
--- a/packages/database/prisma/migrations/20250611021551_add_fallback_fields/migration.sql
+++ b/packages/database/prisma/migrations/20250611021551_add_fallback_fields/migration.sql
@@ -1,0 +1,27 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Activity" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "activityType" TEXT NOT NULL DEFAULT 'LESSON',
+    "milestoneId" INTEGER NOT NULL,
+    "orderIndex" INTEGER NOT NULL DEFAULT 0,
+    "userId" INTEGER,
+    "durationMins" INTEGER,
+    "privateNote" TEXT,
+    "publicNote" TEXT,
+    "materialsText" TEXT,
+    "tags" JSONB NOT NULL DEFAULT [],
+    "isSubFriendly" BOOLEAN NOT NULL DEFAULT true,
+    "isFallback" BOOLEAN NOT NULL DEFAULT false,
+    "completedAt" DATETIME,
+    CONSTRAINT "Activity_milestoneId_fkey" FOREIGN KEY ("milestoneId") REFERENCES "Milestone" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Activity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Activity" ("activityType", "completedAt", "durationMins", "id", "materialsText", "milestoneId", "orderIndex", "privateNote", "publicNote", "tags", "title", "userId") SELECT "activityType", "completedAt", "durationMins", "id", "materialsText", "milestoneId", "orderIndex", "privateNote", "publicNote", "tags", "title", "userId" FROM "Activity";
+DROP TABLE "Activity";
+ALTER TABLE "new_Activity" RENAME TO "Activity";
+CREATE INDEX "Activity_milestoneId_orderIndex_idx" ON "Activity"("milestoneId", "orderIndex");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -54,6 +54,10 @@ model Activity {
   materialsText String?
   /// Optional list of activity tags (e.g. "HandsOn")
   tags         Json     @default("[]")
+  /// True if suitable for substitute teachers
+  isSubFriendly Boolean  @default(true)
+  /// Mark as generic fallback activity for the subject
+  isFallback   Boolean   @default(false)
   completedAt  DateTime?
   weeklySchedules WeeklySchedule[]
   resources   Resource[]

--- a/packages/database/prisma/seed/fallbackActivities.json
+++ b/packages/database/prisma/seed/fallbackActivities.json
@@ -1,0 +1,9 @@
+[
+  {
+    "subject": "Math",
+    "title": "Math Review Worksheets",
+    "publicNote": "Complete practice problems."
+  },
+  { "subject": "Science", "title": "Science Video", "publicNote": "Watch assigned clip." },
+  { "subject": "Health", "title": "Health Journal", "publicNote": "Write about healthy choices." }
+]

--- a/server/tests/fallbackActivity.test.ts
+++ b/server/tests/fallbackActivity.test.ts
@@ -1,0 +1,56 @@
+import { prisma } from '../src/prisma';
+import { buildSubPlanData } from '../src/services/subPlanService';
+
+describe('fallback activities', () => {
+  beforeAll(async () => {
+    await prisma.$queryRawUnsafe('PRAGMA busy_timeout = 20000');
+    await prisma.dailyPlanItem.deleteMany();
+    await prisma.dailyPlan.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+  });
+
+  afterAll(async () => {
+    await prisma.dailyPlanItem.deleteMany();
+    await prisma.dailyPlan.deleteMany();
+    await prisma.lessonPlan.deleteMany();
+    await prisma.activity.deleteMany();
+    await prisma.milestone.deleteMany();
+    await prisma.subject.deleteMany();
+    await prisma.$disconnect();
+  });
+
+  it('selects fallback when planned activity not sub-friendly', async () => {
+    const subject = await prisma.subject.create({ data: { name: 'Math' } });
+    const milestone = await prisma.milestone.create({
+      data: { title: 'M', subjectId: subject.id },
+    });
+    const act = await prisma.activity.create({
+      data: { title: 'Hard Task', milestoneId: milestone.id, isSubFriendly: false },
+    });
+    const fbMilestone = await prisma.milestone.create({
+      data: { title: 'Fallback Activities', subjectId: subject.id },
+    });
+    await prisma.activity.create({
+      data: {
+        title: 'Worksheet',
+        milestoneId: fbMilestone.id,
+        isSubFriendly: true,
+        isFallback: true,
+      },
+    });
+    const plan = await prisma.lessonPlan.create({ data: { weekStart: new Date('2025-06-15') } });
+    await prisma.dailyPlan.create({
+      data: {
+        date: new Date('2025-06-15'),
+        lessonPlanId: plan.id,
+        items: { create: { startMin: 540, endMin: 600, activityId: act.id } },
+      },
+    });
+
+    const data = await buildSubPlanData('2025-06-15');
+    expect(data.schedule[0].activity).toBe('Worksheet');
+  });
+});


### PR DESCRIPTION
## Summary
- add `isSubFriendly` and `isFallback` fields on activities
- seed fallback activities if none exist
- return fallback activities during sub plan generation
- test fallback selection logic

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848e5f29710832db1a0639f37ec43ff