### PR TITLE
Implement local database backup

### DIFF
--- a/client/src/components/settings/BackupButton.tsx
+++ b/client/src/components/settings/BackupButton.tsx
@@ -1,0 +1,13 @@
+import { toast } from 'sonner';
+
+export default function BackupButton() {
+  const handleClick = () => {
+    toast.message('Backup starting…');
+    window.location.href = '/api/backup';
+  };
+  return (
+    <button className="px-2 py-1 bg-blue-600 text-white" onClick={handleClick}>
+      Download Backup
+    </button>
+  );
+}

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import HolidaySettings from '../components/settings/HolidaySettings';
 import SubstituteInfoForm from '../components/settings/SubstituteInfoForm';
+import BackupButton from '../components/settings/BackupButton';
 
 export default function SettingsPage() {
   return (
@@ -7,6 +8,7 @@ export default function SettingsPage() {
       <h1 className="text-xl">Settings</h1>
       <HolidaySettings />
       <SubstituteInfoForm />
+      <BackupButton />
     </div>
   );
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import equipmentBookingRoutes from './routes/equipmentBooking';
 import holidayRoutes from './routes/holiday';
 import weekRoutes from './routes/week';
 import substituteInfoRoutes from './routes/substituteInfo';
+import backupRoutes from './routes/backupRoutes';
 import { scheduleProgressCheck } from './jobs/progressCheck';
 import { scheduleUnreadNotificationEmails } from './jobs/unreadNotificationEmail';
 import { scheduleNewsletterTriggers } from './jobs/newsletterTrigger';
@@ -73,6 +74,7 @@ app.use('/api/equipment-bookings', equipmentBookingRoutes);
 app.use('/api/holidays', holidayRoutes);
 app.use('/api/weeks', weekRoutes);
 app.use('/api/substitute-info', substituteInfoRoutes);
+app.use('/api/backup', backupRoutes);
 app.post('/api/preferences', savePreferences);
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });

--- a/server/src/routes/backupRoutes.ts
+++ b/server/src/routes/backupRoutes.ts
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import path from 'path';
+import fs from 'fs';
+import archiver from 'archiver';
+
+const router = Router();
+
+function getDbPath() {
+  const url = process.env.DATABASE_URL || '';
+  const match = url.match(/file:(.*)/);
+  if (match) {
+    return path.resolve(process.cwd(), match[1]);
+  }
+  return path.resolve(process.cwd(), 'prisma/dev.db');
+}
+
+function getUploadsPath() {
+  return path.join(__dirname, '../uploads');
+}
+
+router.get('/', async (_req, res, next) => {
+  try {
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', 'attachment; filename="backup.zip"');
+
+    const archive = archiver('zip');
+    archive.on('error', (err) => next(err));
+    archive.pipe(res);
+
+    const db = getDbPath();
+    archive.file(db, { name: 'database.sqlite' });
+    const uploads = getUploadsPath();
+    if (fs.existsSync(uploads)) {
+      archive.directory(uploads, 'uploads');
+    }
+    archive.finalize();
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/tests/backupRoutes.test.ts
+++ b/server/tests/backupRoutes.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import app from '../src/index';
+import fs from 'fs/promises';
+import path from 'path';
+import unzipper from 'unzipper';
+
+const binaryParser = (
+  res: NodeJS.ReadableStream,
+  callback: (err: Error | null, data: Buffer) => void,
+) => {
+  const data: Buffer[] = [];
+  res.on('data', (chunk) => data.push(Buffer.from(chunk)));
+  res.on('end', () => callback(null, Buffer.concat(data)));
+};
+
+describe('backup route', () => {
+  const dbPath = path.resolve('test-route.sqlite');
+  const uploads = path.join(__dirname, '../src/uploads');
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = `file:${dbPath}`;
+    await fs.writeFile(dbPath, 'data');
+    await fs.mkdir(uploads, { recursive: true });
+    await fs.writeFile(path.join(uploads, 'file.txt'), 'hi');
+  });
+
+  afterAll(async () => {
+    await fs.rm(dbPath, { force: true });
+    await fs.rm(uploads, { recursive: true, force: true });
+  });
+
+  it('streams zip with db and uploads', async () => {
+    const res = await request(app).get('/api/backup').buffer().parse(binaryParser);
+    expect(res.status).toBe(200);
+    const dir = await unzipper.Open.buffer(res.body);
+    const names = dir.files.map((f) => f.path).sort();
+    expect(names).toEqual(['database.sqlite', 'uploads/file.txt']);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/backup` route to stream zipped database and uploads
- expose `BackupButton` in settings page to download the backup with toast feedback
- test backup route to ensure both database and uploads are included

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848edb80bbc832db80d95c7f4a55206