### PR TITLE
Implement lazy loading and docs check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Verify docs
+        run: pnpm run check:docs
+
       - name: Build
         run: pnpm run build
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,9 @@
 import { Route, Routes } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
 import SubjectsPage from './pages/SubjectsPage';
 import SubjectDetailPage from './pages/SubjectDetailPage';
 import MilestoneDetailPage from './pages/MilestoneDetailPage';
-import WeeklyPlannerPage from './pages/WeeklyPlannerPage';
 import NotificationsPage from './pages/NotificationsPage';
-import NewsletterEditor from './pages/NewsletterEditor';
 import NewsletterDraftViewer from './pages/NewsletterDraftViewer';
 import DailyPlanPage from './pages/DailyPlanPage';
 import TimetablePage from './pages/TimetablePage';
@@ -13,6 +12,9 @@ import DashboardPage from './pages/DashboardPage';
 import NotesPage from './pages/NotesPage';
 import ReflectionsPage from './pages/ReflectionsPage';
 import SettingsPage from './pages/SettingsPage';
+
+const WeeklyPlannerPage = lazy(() => import('./pages/WeeklyPlannerPage'));
+const NewsletterEditor = lazy(() => import('./pages/NewsletterEditor'));
 import { NotificationProvider } from './contexts/NotificationContext';
 
 export default function App() {
@@ -23,14 +25,28 @@ export default function App() {
         <Route path="/subjects" element={<SubjectsPage />} />
         <Route path="/subjects/:id" element={<SubjectDetailPage />} />
         <Route path="/milestones/:id" element={<MilestoneDetailPage />} />
-        <Route path="/planner" element={<WeeklyPlannerPage />} />
+        <Route
+          path="/planner"
+          element={
+            <Suspense fallback={<div>Loading...</div>}>
+              <WeeklyPlannerPage />
+            </Suspense>
+          }
+        />
         <Route path="/timetable" element={<TimetablePage />} />
         <Route path="/year" element={<YearAtAGlancePage />} />
         <Route path="/daily" element={<DailyPlanPage />} />
         <Route path="/notes" element={<NotesPage />} />
         <Route path="/notifications" element={<NotificationsPage />} />
         <Route path="/reflections" element={<ReflectionsPage />} />
-        <Route path="/newsletters/new" element={<NewsletterEditor />} />
+        <Route
+          path="/newsletters/new"
+          element={
+            <Suspense fallback={<div>Loading...</div>}>
+              <NewsletterEditor />
+            </Suspense>
+          }
+        />
         <Route path="/newsletters/draft" element={<NewsletterDraftViewer />} />
         <Route path="/settings" element={<SettingsPage />} />
       </Routes>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -19,4 +19,7 @@ export default defineConfig({
     globals: true,
     setupFiles: './src/setupTests.ts',
   },
+  build: {
+    sourcemap: true,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "playwright:test": "playwright test",
     "preplaywright:test": "pnpm exec playwright install --with-deps",
     "test:e2e": "pnpm playwright:test",
-    "test:all": "pnpm run test && pnpm run test:e2e"
+    "test:all": "pnpm run test && pnpm run test:e2e",
+    "check:docs": "pnpm --filter scripts run verify-docs",
+    "analyze:bundle": "source-map-explorer 'client/dist/assets/index-*.js' --no-border-checks --html client/dist/bundle-report.html"
   },
   "devDependencies": {
     "@playwright/test": "^1.43.1",
@@ -36,7 +38,8 @@
     "husky": "^8.0.0",
     "lint-staged": "^15.0.0",
     "pdf-parse": "^1.1.1",
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "source-map-explorer": "^2.5.3"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.5.3
+      source-map-explorer:
+        specifier: ^2.5.3
+        version: 2.5.3
 
   client:
     dependencies:
@@ -3379,6 +3382,14 @@ packages:
         integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==,
       }
 
+  btoa@1.2.1:
+    resolution:
+      {
+        integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==,
+      }
+    engines: { node: '>= 0.4.0' }
+    hasBin: true
+
   buffer-crc32@1.0.0:
     resolution:
       {
@@ -3554,6 +3565,12 @@ packages:
       }
     engines: { node: '>=18' }
 
+  cliui@7.0.4:
+    resolution:
+      {
+        integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==,
+      }
+
   cliui@8.0.1:
     resolution:
       {
@@ -3667,6 +3684,12 @@ packages:
         integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
       }
     engines: { node: '>= 0.6' }
+
+  convert-source-map@1.9.0:
+    resolution:
+      {
+        integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==,
+      }
 
   convert-source-map@2.0.0:
     resolution:
@@ -4033,6 +4056,12 @@ packages:
     resolution:
       {
         integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==,
+      }
+
+  duplexer@0.1.2:
+    resolution:
+      {
+        integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==,
       }
 
   eastasianwidth@0.2.0:
@@ -4749,6 +4778,13 @@ packages:
         integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==,
       }
 
+  gzip-size@6.0.0:
+    resolution:
+      {
+        integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==,
+      }
+    engines: { node: '>=10' }
+
   handlebars@4.7.8:
     resolution:
       {
@@ -5049,6 +5085,14 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  is-docker@2.2.1:
+    resolution:
+      {
+        integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==,
+      }
+    engines: { node: '>=8' }
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution:
       {
@@ -5193,6 +5237,13 @@ packages:
         integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
       }
     engines: { node: '>= 0.4' }
+
+  is-wsl@2.2.0:
+    resolution:
+      {
+        integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==,
+      }
+    engines: { node: '>=8' }
 
   isarray@1.0.0:
     resolution:
@@ -5974,6 +6025,13 @@ packages:
       }
     engines: { node: '>=16 || 14 >=14.17' }
 
+  mkdirp@0.5.6:
+    resolution:
+      {
+        integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==,
+      }
+    hasBin: true
+
   mlly@1.7.4:
     resolution:
       {
@@ -6209,6 +6267,13 @@ packages:
         integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
       }
     engines: { node: '>=18' }
+
+  open@7.4.2:
+    resolution:
+      {
+        integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==,
+      }
+    engines: { node: '>=8' }
 
   openai@5.3.0:
     resolution:
@@ -6953,6 +7018,14 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
+  rimraf@2.6.3:
+    resolution:
+      {
+        integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==,
+      }
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rimraf@3.0.2:
     resolution:
       {
@@ -7209,6 +7282,14 @@ packages:
       react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
+  source-map-explorer@2.5.3:
+    resolution:
+      {
+        integrity: sha512-qfUGs7UHsOBE5p/lGfQdaAj/5U/GWYBw2imEpD6UQNkqElYonkow8t+HBL1qqIl3CuGZx7n8/CQo4x1HwSHhsg==,
+      }
+    engines: { node: '>=12' }
+    hasBin: true
+
   source-map-js@1.2.1:
     resolution:
       {
@@ -7228,6 +7309,13 @@ packages:
         integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
       }
     engines: { node: '>=0.10.0' }
+
+  source-map@0.7.4:
+    resolution:
+      {
+        integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==,
+      }
+    engines: { node: '>= 8' }
 
   spawn-command@0.0.2:
     resolution:
@@ -7464,6 +7552,13 @@ packages:
       {
         integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==,
       }
+
+  temp@0.9.4:
+    resolution:
+      {
+        integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==,
+      }
+    engines: { node: '>=6.0.0' }
 
   test-exclude@6.0.0:
     resolution:
@@ -8154,12 +8249,26 @@ packages:
     engines: { node: '>= 14.6' }
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution:
+      {
+        integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==,
+      }
+    engines: { node: '>=10' }
+
   yargs-parser@21.1.1:
     resolution:
       {
         integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
       }
     engines: { node: '>=12' }
+
+  yargs@16.2.0:
+    resolution:
+      {
+        integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==,
+      }
+    engines: { node: '>=10' }
 
   yargs@17.7.2:
     resolution:
@@ -10558,6 +10667,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  btoa@1.2.1: {}
+
   buffer-crc32@1.0.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
@@ -10655,6 +10766,12 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -10714,6 +10831,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
+
+  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -10907,6 +11026,8 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -11434,6 +11555,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -11621,6 +11746,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-docker@2.2.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -11686,6 +11813,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isarray@1.0.0: {}
 
@@ -12336,6 +12467,10 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
+
   mlly@1.7.4:
     dependencies:
       acorn: 8.15.0
@@ -12451,6 +12586,11 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   openai@5.3.0(ws@8.18.2)(zod@3.25.56):
     optionalDependencies:
@@ -12860,6 +13000,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rimraf@2.6.3:
+    dependencies:
+      glob: 7.2.3
+
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -13044,6 +13188,21 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  source-map-explorer@2.5.3:
+    dependencies:
+      btoa: 1.2.1
+      chalk: 4.1.2
+      convert-source-map: 1.9.0
+      ejs: 3.1.10
+      escape-html: 1.0.3
+      glob: 7.2.3
+      gzip-size: 6.0.0
+      lodash: 4.17.21
+      open: 7.4.2
+      source-map: 0.7.4
+      temp: 0.9.4
+      yargs: 16.2.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
@@ -13052,6 +13211,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  source-map@0.7.4: {}
 
   spawn-command@0.0.2: {}
 
@@ -13218,6 +13379,11 @@ snapshots:
       b4a: 1.6.7
       fast-fifo: 1.3.2
       streamx: 2.22.1
+
+  temp@0.9.4:
+    dependencies:
+      mkdirp: 0.5.6
+      rimraf: 2.6.3
 
   test-exclude@6.0.0:
     dependencies:
@@ -13617,7 +13783,19 @@ snapshots:
 
   yaml@2.8.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "seed": "ts-node seed.ts",
+    "verify-docs": "node verify-screenshots.js",
     "test": "echo skipped"
   },
   "dependencies": {

--- a/scripts/verify-screenshots.js
+++ b/scripts/verify-screenshots.js
@@ -1,0 +1,38 @@
+/* eslint-env node */
+import fs from 'fs';
+import path from 'path';
+
+const guidePath = path.resolve('USER_GUIDE.md');
+if (!fs.existsSync(guidePath)) {
+  console.log('USER_GUIDE.md not found, skipping screenshot verification.');
+  process.exit(0);
+}
+
+const md = fs.readFileSync(guidePath, 'utf8');
+const regex = /!\[[^\]]*\]\(([^)]+)\)/g;
+const imagesDir = path.resolve('docs/images');
+const missing = [];
+const notInDir = [];
+let match;
+while ((match = regex.exec(md))) {
+  const imgPath = match[1];
+  const absolute = path.resolve(path.dirname(guidePath), imgPath);
+  if (!absolute.startsWith(imagesDir)) {
+    notInDir.push(imgPath);
+  }
+  if (!fs.existsSync(absolute)) {
+    missing.push(imgPath);
+  }
+}
+
+if (missing.length || notInDir.length) {
+  if (notInDir.length) {
+    console.error('Images not in docs/images:', notInDir.join(', '));
+  }
+  if (missing.length) {
+    console.error('Missing images:', missing.join(', '));
+  }
+  process.exit(1);
+}
+
+console.log('All referenced screenshots are present.');


### PR DESCRIPTION
## Summary
- lazy load `WeeklyPlannerPage` and `NewsletterEditor` via `React.lazy`
- add docs screenshot checker script
- call docs checker in CI
- expose `check:docs` npm script
- enable source maps for bundle analysis

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run check:docs`
- `pnpm run analyze:bundle`

------
https://chatgpt.com/codex/tasks/task_e_6848f43c2b94832d9c36dc39f108fdad