### PR TITLE
Fix lesson plan upsert and update dependencies

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -68,7 +68,7 @@ model Activity {
 
 model LessonPlan {
   id         Int             @id @default(autoincrement())
-  weekStart  DateTime
+  weekStart  DateTime        @unique
   schedule   WeeklySchedule[]
   dailyPlans DailyPlan[]
   createdAt  DateTime        @default(now())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         version: 6.10.1
       openai:
         specifier: ^5.3.0
-        version: 5.3.0(ws@8.18.2)(zod@3.25.56)
+        version: 5.3.0(ws@8.18.2)(zod@3.25.58)
       pdfkit:
         specifier: ^0.17.1
         version: 0.17.1
@@ -191,8 +191,8 @@ importers:
         specifier: ^0.12.3
         version: 0.12.3
       zod:
-        specifier: 3.25.56
-        version: 3.25.56
+        specifier: 3.25.58
+        version: 3.25.58
     devDependencies:
       '@types/archiver':
         specifier: ^6.0.3
@@ -246,8 +246,8 @@ importers:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@18.19.111)(typescript@5.8.3)
       tsx:
-        specifier: ^4.19.4
-        version: 4.19.4
+        specifier: ^4.20.0
+        version: 4.20.0
       typescript:
         specifier: ^5.2.2
         version: 5.8.3
@@ -7744,6 +7744,14 @@ packages:
     engines: { node: '>=18.0.0' }
     hasBin: true
 
+  tsx@4.20.0:
+    resolution:
+      {
+        integrity: sha512-TsmdeXxcZYiJ2MKV7fdq38na0CKyLRtCeMqTeHMmrVXQ/gf5yTeJohh+sgr7MnMGsjeKXzHzy+TwOOTR1arl+Q==,
+      }
+    engines: { node: '>=18.0.0' }
+    hasBin: true
+
   type-check@0.4.0:
     resolution:
       {
@@ -8305,10 +8313,10 @@ packages:
       }
     engines: { node: '>= 14' }
 
-  zod@3.25.56:
+  zod@3.25.58:
     resolution:
       {
-        integrity: sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==,
+        integrity: sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==,
       }
 
 snapshots:
@@ -12592,10 +12600,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@5.3.0(ws@8.18.2)(zod@3.25.56):
+  openai@5.3.0(ws@8.18.2)(zod@3.25.58):
     optionalDependencies:
       ws: 8.18.2
-      zod: 3.25.56
+      zod: 3.25.58
 
   optionator@0.9.4:
     dependencies:
@@ -13493,6 +13501,13 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tsx@4.20.0:
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -13819,4 +13834,4 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod@3.25.56: {}
+  zod@3.25.58: {}

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,7 @@
     "pdfkit": "^0.17.1",
     "pino": "8.21.0",
     "unzipper": "^0.12.3",
-    "zod": "3.25.56"
+    "zod": "3.25.58"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.3",
@@ -46,7 +46,7 @@
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "tsx": "^4.19.4",
+    "tsx": "^4.20.0",
     "typescript": "^5.2.2"
   }
 }

--- a/server/src/routes/lessonPlan.ts
+++ b/server/src/routes/lessonPlan.ts
@@ -69,32 +69,17 @@ router.post('/generate', async (req, res, next) => {
     if (scheduleData.length === 0) {
       return res.status(400).json({ error: 'No activities available' });
     }
-    const existing = await prisma.lessonPlan.findFirst({
+    const plan = await prisma.lessonPlan.upsert({
       where: { weekStart: new Date(weekStart) },
+      create: {
+        weekStart: new Date(weekStart),
+        schedule: { create: scheduleData },
+      },
+      update: {
+        schedule: { deleteMany: {}, create: scheduleData },
+      },
+      include: { schedule: { include: { slot: true } } },
     });
-    let plan;
-    if (existing) {
-      plan = await prisma.lessonPlan.update({
-        where: { id: existing.id },
-        data: {
-          schedule: {
-            deleteMany: {},
-            create: scheduleData,
-          },
-        },
-        include: { schedule: { include: { slot: true } } },
-      });
-    } else {
-      plan = await prisma.lessonPlan.create({
-        data: {
-          weekStart: new Date(weekStart),
-          schedule: {
-            create: scheduleData,
-          },
-        },
-        include: { schedule: { include: { slot: true } } },
-      });
-    }
     await updateMaterialList(weekStart);
     res.status(201).json(plan);
   } catch (err) {


### PR DESCRIPTION
## Summary
- add missing unique constraint to `LessonPlan.weekStart`
- upsert lesson plans by weekStart to avoid duplicate rows
- bump zod and tsx versions

## Testing
- `pnpm --filter server test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6848ff0140c4832db800da62bd5d7879