### PR TITLE
Fix e2e test setup

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,8 +11,10 @@ export default defineConfig({
     stdout: 'pipe',
     stderr: 'pipe',
     env: {
-      NODE_ENV: 'test',
-      PORT: '5173',
+      // Use development mode so the Express server actually starts
+      NODE_ENV: 'development',
+      // Run the API server on its default port
+      PORT: '3001',
       DATABASE_URL: 'file:./test.db',
     },
   },

--- a/server/tests/setup-test-db.ts
+++ b/server/tests/setup-test-db.ts
@@ -6,5 +6,5 @@ export default async function setup() {
   await envSetup();
   const root = resolve(__dirname, '..', '..');
   execSync('pnpm db:generate', { stdio: 'inherit', cwd: root });
-  execSync('pnpm db:deploy', { stdio: 'inherit', cwd: root });
+  execSync('pnpm db:push --force-reset', { stdio: 'inherit', cwd: root });
 }

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { login } from './e2e/helpers';
 
 test('create subject, milestone and activity', async ({ page }) => {
+  await login(page);
   await page.goto('/subjects');
 
   // open subject dialog

--- a/tests/e2e/activity-reorder.spec.ts
+++ b/tests/e2e/activity-reorder.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 // drag first activity to last and ensure order persists
 
 test('reorders activities within milestone', async ({ page }) => {
   const ts = Date.now();
+  await login(page);
   await page.goto('/subjects');
 
   await page.click('text=Add Subject');

--- a/tests/e2e/calendar-blocking.spec.ts
+++ b/tests/e2e/calendar-blocking.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 /**
  * Test that verifies the planner correctly blocks times based on calendar events.
@@ -18,6 +19,7 @@ test('planner blocks times from calendar events', async ({ page }) => {
     },
   });
 
+  await login(page);
   await page.goto('/planner');
   const blocked = page.locator('text=Assembly').first();
   await expect(blocked).toBeVisible();

--- a/tests/e2e/duration-conflict.spec.ts
+++ b/tests/e2e/duration-conflict.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 // dragging long activity into short slot should be rejected
 
 test('rejects drop when activity longer than slot', async ({ page }) => {
   const ts = Date.now();
+  await login(page);
   await page.goto('/subjects');
   await page.click('text=Add Subject');
   await page.fill('input[placeholder="New subject"]', `Dur${ts}`);

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,10 @@
+import { Page } from '@playwright/test';
+
+export async function login(page: Page) {
+  await page.goto('/login');
+  await page.fill('input[name="email"]', 'teacher@example.com');
+  await page.fill('input[name="password"]', 'password123');
+  await page.click('button:has-text("Sign in")');
+  // wait for navigation to complete
+  await page.waitForLoadState('networkidle');
+}

--- a/tests/e2e/holiday-planner.spec.ts
+++ b/tests/e2e/holiday-planner.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 // Ensure planner skips holidays when auto-filling
 
@@ -13,6 +14,7 @@ test('planner skips holiday dates', async ({ page }) => {
     data: [{ day: 3, startMin: 540, endMin: 600, subjectId }],
   });
 
+  await login(page);
   await page.goto('/settings');
   await page.fill('input[type="date"]', '2025-12-25');
   await page.fill('input[placeholder="Holiday name"]', 'Christmas');

--- a/tests/e2e/planner-filters.spec.ts
+++ b/tests/e2e/planner-filters.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 test('planner tag filters', async ({ page }) => {
   const ts = Date.now();
+  await login(page);
   await page.goto('/subjects');
   await page.click('text=Add Subject');
   await page.fill('input[placeholder="New subject"]', `F${ts}`);

--- a/tests/e2e/reflections-filter.spec.ts
+++ b/tests/e2e/reflections-filter.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 test('filters notes by subject and type', async ({ page }) => {
   const ts = Date.now();
@@ -42,6 +43,7 @@ test('filters notes by subject and type', async ({ page }) => {
     data: { content: 'Sci Public', type: 'public', activityId: sciActId },
   });
 
+  await login(page);
   await page.goto('/reflections');
   await page.selectOption('select', `${mathId}`);
   await page.check('label:has-text("Public") input');

--- a/tests/e2e/subplan-ical.spec.ts
+++ b/tests/e2e/subplan-ical.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
@@ -22,6 +23,7 @@ test('ical import blocks planner and sub plan lists event', async ({ page }) => 
 
   await page.request.post('/api/calendar-events/sync/ical', { data: { feedUrl } });
 
+  await login(page);
   await page.goto('/planner');
   await page.fill('input[type="date"]', '2025-01-01');
   await page.waitForResponse(

--- a/tests/e2e/weekly-planning.spec.ts
+++ b/tests/e2e/weekly-planning.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { login } from './helpers';
 
 test('generate weekly plan from activity', async ({ page }) => {
   const ts = Date.now();
+  await login(page);
   await page.goto('/subjects');
 
   await page.click('text=Add Subject');


### PR DESCRIPTION
## Summary
- run Express server in dev mode during e2e
- reset DB in Jest setup
- add Playwright login helper and use in specs

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run test:e2e` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_684b85a1104c832da0f38b903faec7a9