### PR TITLE
Stabilize Playwright flows

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -19,6 +19,7 @@ test('create subject, milestone and activity', async ({ page }) => {
   await page.click('button:has-text("Save")');
 
   // navigate to the milestone detail page
+  await page.waitForSelector('text=M1', { timeout: 30000 });
   await page.click('text=M1');
 
   // open activity dialog

--- a/tests/e2e/activity-reorder.spec.ts
+++ b/tests/e2e/activity-reorder.spec.ts
@@ -16,6 +16,7 @@ test('reorders activities within milestone', async ({ page }) => {
   await page.click('text=Add Milestone');
   await page.fill('input[placeholder="New milestone"]', 'M');
   await page.click('button:has-text("Save")');
+  await page.waitForSelector('a:has-text("M")', { timeout: 30000 });
   await page.click('a:has-text("M")');
   await page.waitForSelector('button:has-text("Add Activity")');
 

--- a/tests/e2e/calendar-blocking.spec.ts
+++ b/tests/e2e/calendar-blocking.spec.ts
@@ -7,6 +7,7 @@ import { login } from './helpers';
  * Now enabled as the feature is fully implemented and stable.
  */
 test('planner blocks times from calendar events', async ({ page }) => {
+  await login(page);
   await page.addInitScript(() => localStorage.setItem('onboarded', 'true'));
   const today = new Date().toISOString().split('T')[0];
   await page.request.post('/api/calendar-events', {
@@ -18,8 +19,6 @@ test('planner blocks times from calendar events', async ({ page }) => {
       eventType: 'ASSEMBLY',
     },
   });
-
-  await login(page);
   await page.goto('/planner');
   const blocked = page.locator('text=Assembly').first();
   await expect(blocked).toBeVisible();

--- a/tests/e2e/duration-conflict.spec.ts
+++ b/tests/e2e/duration-conflict.spec.ts
@@ -15,6 +15,7 @@ test('rejects drop when activity longer than slot', async ({ page }) => {
   await page.click('text=Add Milestone');
   await page.fill('input[placeholder="New milestone"]', 'Mdur');
   await page.click('button:has-text("Save")');
+  await page.waitForSelector('text=Mdur', { timeout: 30000 });
   await page.click('text=Mdur');
 
   const mRes = await page.request.get('/api/milestones');

--- a/tests/e2e/holiday-planner.spec.ts
+++ b/tests/e2e/holiday-planner.spec.ts
@@ -5,6 +5,7 @@ import { login } from './helpers';
 
 test('planner skips holiday dates', async ({ page }) => {
   const ts = Date.now();
+  await login(page);
   const subRes = await page.request.post('/api/subjects', { data: { name: `H${ts}` } });
   const subjectId = (await subRes.json()).id as number;
   const msRes = await page.request.post('/api/milestones', { data: { title: 'HM', subjectId } });
@@ -14,7 +15,6 @@ test('planner skips holiday dates', async ({ page }) => {
     data: [{ day: 3, startMin: 540, endMin: 600, subjectId }],
   });
 
-  await login(page);
   await page.goto('/settings');
   await page.fill('input[type="date"]', '2025-12-25');
   await page.fill('input[placeholder="Holiday name"]', 'Christmas');

--- a/tests/e2e/planner-filters.spec.ts
+++ b/tests/e2e/planner-filters.spec.ts
@@ -13,6 +13,7 @@ test('planner tag filters', async ({ page }) => {
   await page.click('text=Add Milestone');
   await page.fill('input[placeholder="New milestone"]', `M${ts}`);
   await page.click('button:has-text("Save")');
+  await page.waitForSelector(`text=M${ts}`, { timeout: 30000 });
   await page.click(`text=M${ts}`);
 
   const mRes = await page.request.get('/api/milestones');

--- a/tests/e2e/reflections-filter.spec.ts
+++ b/tests/e2e/reflections-filter.spec.ts
@@ -3,6 +3,7 @@ import { login } from './helpers';
 
 test('filters notes by subject and type', async ({ page }) => {
   const ts = Date.now();
+  await login(page);
   await page.request.post('/api/subjects', { data: { name: `Math${ts}` } });
   await page.request.post('/api/subjects', { data: { name: `Sci${ts}` } });
 
@@ -43,7 +44,6 @@ test('filters notes by subject and type', async ({ page }) => {
     data: { content: 'Sci Public', type: 'public', activityId: sciActId },
   });
 
-  await login(page);
   await page.goto('/reflections');
   await page.selectOption('select', `${mathId}`);
   await page.check('label:has-text("Public") input');

--- a/tests/e2e/subplan-ical.spec.ts
+++ b/tests/e2e/subplan-ical.spec.ts
@@ -21,11 +21,13 @@ test('ical import blocks planner and sub plan lists event', async ({ page }) => 
   const { port } = srv.address() as import('net').AddressInfo;
   const feedUrl = `http://127.0.0.1:${port}/sample.ics`;
 
+  await login(page);
   await page.request.post('/api/calendar-events/sync/ical', { data: { feedUrl } });
 
-  await login(page);
   await page.goto('/planner');
-  await page.fill('input[type="date"]', '2025-01-01');
+  const dateInput = page.locator('input[type="date"]');
+  await dateInput.waitFor({ state: 'visible' });
+  await dateInput.fill('2025-01-01');
   await page.waitForResponse(
     (r) => r.url().includes('/calendar-events') && r.request().method() === 'GET',
   );

--- a/tests/e2e/weekly-planning.spec.ts
+++ b/tests/e2e/weekly-planning.spec.ts
@@ -14,6 +14,7 @@ test('generate weekly plan from activity', async ({ page }) => {
   await page.click('text=Add Milestone');
   await page.fill('input[placeholder="New milestone"]', 'Mplan');
   await page.click('button:has-text("Save")');
+  await page.waitForSelector('text=Mplan', { timeout: 30000 });
   await page.click('text=Mplan');
 
   await page.click('text=Add Activity');


### PR DESCRIPTION
## Summary
- authenticate before calendar-based tests
- wait longer for milestone creation to appear
- use safer date input handling for subplan iCal test
- add initial login in holiday planner and reflections filter

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run test:e2e` *(fails: TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b91ebf4832d9b87c6afbfb1269b