### PR TITLE
Fix seed data for e2e tests

### DIFF
--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -140,6 +140,31 @@ async function main() {
 
   await Promise.all(timetableSlots);
 
+  // Short milestone titles for E2E tests
+  await prisma.milestone.create({
+    data: {
+      title: 'M1',
+      subjectId: math.id,
+      activities: { create: { title: 'Activity 1' } },
+    },
+  });
+
+  await prisma.milestone.create({
+    data: {
+      title: 'M',
+      subjectId: math.id,
+      activities: { create: { title: 'Activity M' } },
+    },
+  });
+
+  await prisma.milestone.create({
+    data: {
+      title: 'M2',
+      subjectId: science.id,
+      activities: { create: { title: 'Activity 2' } },
+    },
+  });
+
   // Create Math milestones and activities
   const additionMilestone = await prisma.milestone.create({
     data: {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -16,7 +16,7 @@ async function main() {
 
   await prisma.milestone.create({
     data: {
-      title: 'Milestone 1',
+      title: 'M1',
       subjectId: subject1.id,
       activities: {
         create: {
@@ -28,7 +28,19 @@ async function main() {
 
   await prisma.milestone.create({
     data: {
-      title: 'Milestone 2',
+      title: 'M',
+      subjectId: subject1.id,
+      activities: {
+        create: {
+          title: 'Activity M',
+        },
+      },
+    },
+  });
+
+  await prisma.milestone.create({
+    data: {
+      title: 'M2',
       subjectId: subject2.id,
       activities: {
         create: {

--- a/tests/e2e/activity-reorder.spec.ts
+++ b/tests/e2e/activity-reorder.spec.ts
@@ -6,21 +6,18 @@ import { login, API_BASE } from './helpers';
 test('reorders activities within milestone', async ({ page }) => {
   const ts = Date.now();
   const token = await login(page);
-  await page.goto('/subjects');
-
-  await page.click('text=Add Subject');
-  await page.fill('input[placeholder="New subject"]', `Sub${ts}`);
-  await page.click('button:has-text("Save")');
-  await page.click(`text=Sub${ts}`);
-
-  await page.click('text=Add Milestone');
-  await page.fill('input[placeholder="New milestone"]', 'M');
-  await page.click('button:has-text("Save")');
-  const mRes = await page.request.get(`${API_BASE}/api/milestones`, {
+  const subjectRes = await page.request.post(`${API_BASE}/api/subjects`, {
     headers: { Authorization: `Bearer ${token}` },
+    data: { name: `Sub${ts}` },
   });
-  const ms = (await mRes.json()) as Array<{ id: number; title: string }>;
-  const mId = ms.find((m) => m.title === 'M')!.id;
+  const subjectId = (await subjectRes.json()).id as number;
+
+  const milestoneRes = await page.request.post(`${API_BASE}/api/milestones`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { title: 'M', subjectId },
+  });
+  const mId = (await milestoneRes.json()).id as number;
+
   await page.goto(`/milestones/${mId}`);
   await page.waitForSelector('button:has-text("Add Activity")');
 

--- a/tests/e2e/duration-conflict.spec.ts
+++ b/tests/e2e/duration-conflict.spec.ts
@@ -6,21 +6,18 @@ import { login, API_BASE } from './helpers';
 test('rejects drop when activity longer than slot', async ({ page }) => {
   const ts = Date.now();
   const token = await login(page);
-  await page.goto('/subjects');
-  await page.click('text=Add Subject');
-  await page.fill('input[placeholder="New subject"]', `Dur${ts}`);
-  await page.click('button:has-text("Save")');
-  await page.click(`text=Dur${ts}`);
-
-  await page.click('text=Add Milestone');
-  await page.fill('input[placeholder="New milestone"]', 'Mdur');
-  await page.click('button:has-text("Save")');
-  const mRes = await page.request.get(`${API_BASE}/api/milestones`, {
+  const subjectRes = await page.request.post(`${API_BASE}/api/subjects`, {
     headers: { Authorization: `Bearer ${token}` },
+    data: { name: `Dur${ts}` },
   });
-  const milestoneId = (await mRes.json()).find(
-    (m: { id: number; title: string }) => m.title === 'Mdur',
-  )!.id;
+  const subjectId = (await subjectRes.json()).id as number;
+
+  const milestoneRes = await page.request.post(`${API_BASE}/api/milestones`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { title: 'Mdur', subjectId },
+  });
+  const milestoneId = (await milestoneRes.json()).id as number;
+
   await page.goto(`/milestones/${milestoneId}`);
 
   await page.request.post(`${API_BASE}/api/activities`, {


### PR DESCRIPTION
## Summary
- update main seed script to add short milestones M1, M, and M2
- rewrite e2e tests to use API calls instead of UI flows

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684c38118ef8832db3bd1b5a76d15525