### PR TITLE
Seed database in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,11 @@ jobs:
       - name: Test
         run: pnpm run test
 
+      - name: Deploy database schema
+        run: pnpm db:deploy
+
+      - name: Seed database
+        run: pnpm db:seed
+
       - name: Playwright E2E Tests
-        run: pnpm playwright:test
+        run: pnpm run test:e2e

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "db:generate": "pnpm --filter @teaching-engine/database db:generate",
     "db:migrate": "pnpm --filter @teaching-engine/database db:migrate",
     "db:push": "pnpm --filter @teaching-engine/database db:push",
-    "db:deploy": "pnpm --filter @teaching-engine/database db:deploy",
+    "db:deploy": "prisma migrate deploy",
     "db:studio": "pnpm --filter @teaching-engine/database db:studio",
-    "db:seed": "pnpm --filter @teaching-engine/database db:seed",
+    "db:seed": "ts-node scripts/seed.ts",
     "postinstall": "pnpm --filter @teaching-engine/database db:generate",
     "playwright:test": "playwright test",
     "preplaywright:test": "pnpm exec playwright install --with-deps",
@@ -41,7 +41,8 @@
     "pdf-parse": "^1.1.1",
     "prettier": "^3.0.0",
     "source-map-explorer": "^2.5.3",
-    "tsconfig-paths": "^4.2.0"
+    "tsconfig-paths": "^4.2.0",
+    "ts-node": "^10.9.1"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       source-map-explorer:
         specifier: ^2.5.3
         version: 2.5.3
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.2(@types/node@20.19.0)(typescript@5.8.3)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -6,46 +6,31 @@ async function main() {
   await prisma.activity.deleteMany();
   await prisma.milestone.deleteMany();
   await prisma.subject.deleteMany();
+  await prisma.user.deleteMany();
 
-  const subject1 = await prisma.subject.create({
-    data: { name: 'Math' },
+  const user = await prisma.user.create({
+    data: {
+      email: 'teacher@example.com',
+      password: 'password123',
+      name: 'Teacher',
+    },
   });
-  const subject2 = await prisma.subject.create({
-    data: { name: 'Science' },
+
+  const subject = await prisma.subject.create({
+    data: { name: 'Math', userId: user.id },
   });
 
   await prisma.milestone.create({
     data: {
       title: 'M1',
-      subjectId: subject1.id,
+      subjectId: subject.id,
+      userId: user.id,
       activities: {
-        create: {
-          title: 'Activity 1',
-        },
-      },
-    },
-  });
-
-  await prisma.milestone.create({
-    data: {
-      title: 'M',
-      subjectId: subject1.id,
-      activities: {
-        create: {
-          title: 'Activity M',
-        },
-      },
-    },
-  });
-
-  await prisma.milestone.create({
-    data: {
-      title: 'M2',
-      subjectId: subject2.id,
-      activities: {
-        create: {
-          title: 'Activity 2',
-        },
+        create: [
+          { title: 'A1', userId: user.id },
+          { title: 'A2', userId: user.id },
+          { title: 'A3', userId: user.id },
+        ],
       },
     },
   });


### PR DESCRIPTION
## Summary
- run `pnpm db:deploy` and `pnpm db:seed` before E2E tests
- seed script now creates a teacher user and simple sample data
- expose new scripts in `package.json`
- add `ts-node` dev dependency for the seed script

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684c5f86eb94832d91508a79541f4af4