### PR TITLE
Fix Playwright login state

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  globalSetup: './playwright.global-setup',
+  globalSetup: require.resolve('./tests/global-setup'),
 
   webServer: {
     command: 'pnpm dev',
@@ -22,6 +22,7 @@ export default defineConfig({
 
   use: {
     baseURL: 'http://localhost:5173',
+    storageState: 'tests/storage/auth.json',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     actionTimeout: 10000,

--- a/playwright.global-setup.ts
+++ b/playwright.global-setup.ts
@@ -18,7 +18,7 @@ export default async function globalSetup(): Promise<void> {
     process.env.DATABASE_URL = 'file:./test.db';
     execSync('pnpm db:generate', { stdio: 'inherit' });
     execSync('pnpm db:push --force-reset', { stdio: 'inherit' });
-    execSync('pnpm db:seed', { stdio: 'inherit' });
+    execSync('pnpm --filter @teaching-engine/database db:seed', { stdio: 'inherit' });
 
     // Create a new browser context to ensure everything works
     console.log('Verifying browser setup...');

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,14 @@
+import { chromium } from '@playwright/test';
+import baseSetup from '../playwright.global-setup';
+export default async function globalSetup() {
+  await baseSetup();
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:5173/login');
+  await page.fill('input[name="email"]', 'teacher@example.com');
+  await page.fill('input[name="password"]', 'password123');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/');
+  await page.context().storageState({ path: 'tests/storage/auth.json' });
+  await browser.close();
+}


### PR DESCRIPTION
## Summary
- save authenticated state for Playwright tests
- load saved state and use new global setup
- seed DB in global setup to keep default user

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684c620b6e54832db850bbd8ae3962a3