### PR TITLE
feat(planner): integrate outcomes in daily/weekly planner

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -449,8 +449,12 @@ export const useDeleteMilestone = () => {
 export const useCreateActivity = () => {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { title: string; milestoneId: number; materialsText?: string }) =>
-      api.post('/api/activities', data),
+    mutationFn: (data: {
+      title: string;
+      milestoneId: number;
+      materialsText?: string;
+      outcomes?: string[];
+    }) => api.post('/api/activities', data),
     onSuccess: (_res, vars) => {
       qc.invalidateQueries({ queryKey: ['milestone', vars.milestoneId] });
       toast.success('Activity created');
@@ -468,15 +472,18 @@ export const useUpdateActivity = () => {
       title?: string;
       materialsText?: string;
       completedAt?: string | null;
+      outcomes?: string[];
     }) =>
       api.put(`/api/activities/${data.id}`, {
         title: data.title,
         completedAt: data.completedAt,
         materialsText: data.materialsText,
+        outcomes: data.outcomes,
       }),
     onSuccess: (_res, vars) => {
       qc.invalidateQueries({ queryKey: ['milestone', vars.milestoneId] });
       if (vars.subjectId) qc.invalidateQueries({ queryKey: ['subject', vars.subjectId] });
+      qc.invalidateQueries({ queryKey: ['lesson-plan'] });
       toast.success('Activity updated');
     },
   });

--- a/client/src/components/DraggableActivity.tsx
+++ b/client/src/components/DraggableActivity.tsx
@@ -1,6 +1,7 @@
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import type { Activity } from '../api';
+import OutcomeTag from './OutcomeTag';
 
 interface Props {
   activity: Activity;
@@ -13,15 +14,39 @@ export default function DraggableActivity({ activity }: Props) {
 
   const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
 
+  // Determine subject color if there are outcomes
+  const getBorderColor = () => {
+    if (!activity.outcomes || activity.outcomes.length === 0) {
+      return 'border-gray-200';
+    }
+
+    // Use the subject of the first outcome for the border color
+    const subject = activity.outcomes[0].outcome.subject;
+    const hash = subject.split('').reduce((acc, char) => {
+      return char.charCodeAt(0) + ((acc << 5) - acc);
+    }, 0);
+
+    const hue = hash % 360;
+    return `border-l-4 border-l-[hsl(${hue},70%,60%)]`;
+  };
+
   return (
     <li
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       style={style}
-      className="border p-2 bg-white cursor-grab"
+      className={`p-2 bg-white cursor-grab border ${getBorderColor()}`}
     >
-      {activity.title}
+      <div>{activity.title}</div>
+
+      {activity.outcomes && activity.outcomes.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1">
+          {activity.outcomes.map(({ outcome }) => (
+            <OutcomeTag key={outcome.id} outcome={outcome} size="small" />
+          ))}
+        </div>
+      )}
     </li>
   );
 }

--- a/client/src/components/OutcomeSelector.tsx
+++ b/client/src/components/OutcomeSelector.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from 'react';
+import { Outcome, useOutcomes } from '../api';
+
+interface Props {
+  selectedOutcomes: string[];
+  onChange: (outcomes: string[]) => void;
+  className?: string;
+}
+
+export default function OutcomeSelector({ selectedOutcomes, onChange, className = '' }: Props) {
+  const [search, setSearch] = useState('');
+  const [selectedSubject, setSelectedSubject] = useState<string>('');
+  const { data: outcomes = [], isLoading } = useOutcomes({
+    subject: selectedSubject || undefined,
+    search: search || undefined,
+  });
+  const [availableOutcomes, setAvailableOutcomes] = useState<Outcome[]>([]);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  // Extract unique subjects for the dropdown
+  const subjects = [...new Set(outcomes.map((o) => o.subject))];
+
+  // Filter and sort outcomes
+  useEffect(() => {
+    const filtered = outcomes.sort((a, b) => a.code.localeCompare(b.code));
+    setAvailableOutcomes(filtered);
+  }, [outcomes]);
+
+  // Toggle an outcome selection
+  const toggleOutcome = (code: string) => {
+    if (selectedOutcomes.includes(code)) {
+      onChange(selectedOutcomes.filter((c) => c !== code));
+    } else {
+      onChange([...selectedOutcomes, code]);
+    }
+  };
+
+  // Get outcome details by code
+  const getOutcomeByCode = (code: string): Outcome | undefined => {
+    return outcomes.find((o) => o.code === code);
+  };
+
+  return (
+    <div className={className}>
+      <label className="block text-sm font-medium text-gray-700 mb-1">Curriculum Outcomes</label>
+
+      {/* Selected outcomes display */}
+      <div className="mb-2 flex flex-wrap gap-1">
+        {selectedOutcomes.map((code) => {
+          const outcome = getOutcomeByCode(code);
+          return (
+            <div
+              key={code}
+              className="inline-flex items-center px-2 py-1 rounded-md text-xs bg-blue-100 text-blue-800"
+              title={outcome?.description || ''}
+            >
+              <span className="font-mono">{code}</span>
+              <button
+                className="ml-1 text-blue-600 hover:text-blue-800"
+                onClick={() => toggleOutcome(code)}
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+        {selectedOutcomes.length === 0 && (
+          <span className="text-sm text-gray-500 italic">No outcomes selected</span>
+        )}
+      </div>
+
+      {/* Dropdown selector */}
+      <div className="relative">
+        <div className="flex gap-2 mb-2">
+          <input
+            type="text"
+            placeholder="Search outcomes..."
+            className="p-2 border rounded flex-1"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onFocus={() => setDropdownOpen(true)}
+          />
+          <select
+            value={selectedSubject}
+            onChange={(e) => setSelectedSubject(e.target.value)}
+            className="p-2 border rounded"
+          >
+            <option value="">All Subjects</option>
+            {subjects.map((subject) => (
+              <option key={subject} value={subject}>
+                {subject}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="p-2 border rounded bg-gray-100"
+            onClick={() => setDropdownOpen(!dropdownOpen)}
+          >
+            {dropdownOpen ? '▲' : '▼'}
+          </button>
+        </div>
+
+        {dropdownOpen && (
+          <div className="absolute z-10 w-full bg-white border rounded-md shadow-lg max-h-60 overflow-y-auto">
+            {isLoading ? (
+              <div className="p-2 text-center text-gray-500">Loading outcomes...</div>
+            ) : availableOutcomes.length === 0 ? (
+              <div className="p-2 text-center text-gray-500">No outcomes found</div>
+            ) : (
+              <ul className="divide-y divide-gray-200">
+                {availableOutcomes.map((outcome) => (
+                  <li
+                    key={outcome.id}
+                    className={`p-2 cursor-pointer hover:bg-gray-100 ${
+                      selectedOutcomes.includes(outcome.code) ? 'bg-blue-50' : ''
+                    }`}
+                    onClick={() => toggleOutcome(outcome.code)}
+                  >
+                    <div className="flex items-start">
+                      <input
+                        type="checkbox"
+                        checked={selectedOutcomes.includes(outcome.code)}
+                        onChange={() => toggleOutcome(outcome.code)}
+                        className="mt-1 mr-2"
+                      />
+                      <div>
+                        <div className="font-mono text-sm">{outcome.code}</div>
+                        <div className="text-sm">{outcome.description}</div>
+                        <div className="text-xs text-gray-500">
+                          {outcome.subject} - Grade {outcome.grade}
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/OutcomeTag.tsx
+++ b/client/src/components/OutcomeTag.tsx
@@ -1,0 +1,42 @@
+import { Outcome } from '../api';
+
+interface Props {
+  outcome: Outcome;
+  size?: 'small' | 'normal';
+  showTooltip?: boolean;
+}
+
+export default function OutcomeTag({ outcome, size = 'normal', showTooltip = true }: Props) {
+  // Determine background color based on subject
+  const getColorForSubject = (subject: string): string => {
+    // Create a hash from the subject string for consistent colors
+    const hash = subject.split('').reduce((acc, char) => {
+      return char.charCodeAt(0) + ((acc << 5) - acc);
+    }, 0);
+
+    // Generate a hue from 0-360 degrees
+    const hue = hash % 360;
+
+    // Return HSL with lighter saturation and higher lightness for a pastel look
+    return `hsl(${hue}, 70%, 85%)`;
+  };
+
+  const backgroundColor = getColorForSubject(outcome.subject);
+  const textColor = 'text-gray-800'; // Dark text for all pastel backgrounds
+
+  const tooltipContent = showTooltip
+    ? `${outcome.description} (${outcome.subject} - Grade ${outcome.grade})`
+    : undefined;
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-md font-mono ${
+        size === 'small' ? 'px-1 py-0.5 text-xs' : 'px-2 py-1 text-sm'
+      } ${textColor}`}
+      style={{ backgroundColor }}
+      title={tooltipContent}
+    >
+      {outcome.code}
+    </span>
+  );
+}

--- a/client/src/components/WeekCalendarGrid.tsx
+++ b/client/src/components/WeekCalendarGrid.tsx
@@ -1,5 +1,6 @@
 import type { WeeklyScheduleItem, Activity, TimetableSlot, CalendarEvent } from '../api';
 import { useDroppable } from '@dnd-kit/core';
+import OutcomeTag from './OutcomeTag';
 
 interface Props {
   schedule: WeeklyScheduleItem[];
@@ -66,11 +67,31 @@ export default function WeekCalendarGrid({
                 {ev.title}
               </div>
             ))}
-            {items.map((it) => (
-              <div key={it.id} className="mt-1 text-sm">
-                {activities[it.activityId]?.title}
-              </div>
-            ))}
+            {items.map((it) => {
+              const activity = activities[it.activityId];
+              if (!activity) return null;
+
+              // Determine if activity has outcomes attached
+              const hasOutcomes = activity.outcomes && activity.outcomes.length > 0;
+
+              return (
+                <div
+                  key={it.id}
+                  className={`mt-1 text-sm p-1 border rounded ${hasOutcomes ? 'border-blue-200 bg-blue-50' : 'border-gray-200'}`}
+                >
+                  <div>{activity.title}</div>
+
+                  {/* Display outcome tags */}
+                  {hasOutcomes && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {activity.outcomes?.map(({ outcome }) => (
+                        <OutcomeTag key={outcome.id} outcome={outcome} size="small" />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         );
       })}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -22,7 +22,7 @@ export interface Milestone {
   description?: string | null;
   activities: Activity[];
   subject?: Subject;
-  outcomes?: Array<{outcome: Outcome}>;
+  outcomes?: Array<{ outcome: Outcome }>;
 }
 
 export interface Activity {
@@ -41,6 +41,9 @@ export interface Activity {
       name: string;
     };
   };
+  outcomes?: Array<{
+    outcome: Outcome;
+  }>;
 }
 
 export interface Resource {


### PR DESCRIPTION
- Update Activity model with outcomes relationship
- Add outcome selector component for activity forms
- Display outcome tags in activity list and planner views
- Color-code activities by subject in weekly planner
- Add hover tooltips for outcome descriptions
- Update API hooks to support outcome linking

🤖 Generated with [Claude Code](https://claude.ai/code)