### PR TITLE
feat(outcomes): enhance curriculum outcome browser

### DIFF
--- a/client/src/components/OutcomeDetail.tsx
+++ b/client/src/components/OutcomeDetail.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import type { Outcome } from '../api';
+
+interface Props {
+  outcome: Outcome;
+}
+
+export default function OutcomeDetail({ outcome }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
+
+  // Generate a color based on the outcome's subject
+  const getSubjectColor = (subject: string): string => {
+    // Simple hash function to generate consistent colors for subjects
+    const hash = subject.split('').reduce((acc, char) => {
+      return char.charCodeAt(0) + ((acc << 5) - acc);
+    }, 0);
+
+    // Generate a hue from 0-360 degrees
+    const hue = hash % 360;
+
+    // Return HSL color with lighter shade for the background
+    return `hsl(${hue}, 70%, 90%)`;
+  };
+
+  const subjectColor = getSubjectColor(outcome.subject);
+
+  return (
+    <div
+      className="border rounded-md mb-2 overflow-hidden"
+      style={{ borderLeftWidth: '4px', borderLeftColor: subjectColor }}
+    >
+      <div
+        className="flex items-center justify-between p-3 cursor-pointer"
+        onClick={toggleExpanded}
+        style={{ backgroundColor: subjectColor }}
+      >
+        <div className="flex items-center">
+          <span className="font-mono font-medium mr-3">{outcome.code}</span>
+          <span className="text-sm truncate max-w-xs">{outcome.description}</span>
+        </div>
+        <div className="flex items-center">
+          <span className="text-xs bg-white bg-opacity-60 rounded-full px-2 py-0.5 mr-2">
+            Grade {outcome.grade}
+          </span>
+          <span className="transform transition-transform">{expanded ? '▼' : '▶'}</span>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="p-3 bg-white">
+          <p className="mb-2">{outcome.description}</p>
+
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span className="font-semibold">Subject:</span> {outcome.subject}
+            </div>
+            {outcome.domain && (
+              <div>
+                <span className="font-semibold">Domain:</span> {outcome.domain}
+              </div>
+            )}
+            <div>
+              <span className="font-semibold">Grade:</span> {outcome.grade}
+            </div>
+            <div>
+              <span className="font-semibold">Code:</span> {outcome.code}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/OutcomeTooltip.tsx
+++ b/client/src/components/OutcomeTooltip.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useRef } from 'react';
+import type { Outcome } from '../api';
+
+interface Props {
+  outcome: Outcome;
+  children: React.ReactNode;
+}
+
+export default function OutcomeTooltip({ outcome, children }: Props) {
+  const [isVisible, setIsVisible] = useState(false);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseEnter = () => {
+    setIsVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsVisible(false);
+  };
+
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+
+      {isVisible && (
+        <div
+          ref={tooltipRef}
+          className="absolute z-10 p-3 bg-gray-800 text-white text-sm rounded shadow-lg max-w-xs"
+          style={{
+            bottom: '100%',
+            left: '50%',
+            transform: 'translateX(-50%) translateY(-5px)',
+            minWidth: '250px',
+          }}
+        >
+          <div className="font-bold mb-1">
+            {outcome.code} - Grade {outcome.grade}
+          </div>
+          <div className="mb-1">{outcome.description}</div>
+          {outcome.domain && <div className="text-gray-300 text-xs">Domain: {outcome.domain}</div>}
+          <div className="text-gray-300 text-xs">Subject: {outcome.subject}</div>
+          {/* Triangle pointer */}
+          <div
+            className="absolute w-0 h-0 border-l-8 border-r-8 border-t-8 border-solid border-l-transparent border-r-transparent border-t-gray-800"
+            style={{
+              bottom: '-8px',
+              left: '50%',
+              transform: 'translateX(-50%)',
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/OutcomesPage.tsx
+++ b/client/src/pages/OutcomesPage.tsx
@@ -1,14 +1,18 @@
 import { useState } from 'react';
 import { useOutcomes } from '../api';
 import type { Outcome } from '../types';
+import OutcomeTooltip from '../components/OutcomeTooltip';
+import OutcomeDetail from '../components/OutcomeDetail';
 
 export default function OutcomesPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedSubject, setSelectedSubject] = useState<string>('');
   const [selectedGrade, setSelectedGrade] = useState<string>('');
+  const [selectedDomain, setSelectedDomain] = useState<string>('');
   const [sortField, setSortField] = useState<keyof Outcome>('code');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const [searchFilters, setSearchFilters] = useState<Record<string, string>>({});
+  const [viewMode, setViewMode] = useState<'table' | 'cards' | 'details'>('table');
 
   // Use the API hook to fetch outcomes
   // Use React Query hook to fetch outcomes from API
@@ -23,6 +27,7 @@ export default function OutcomesPage() {
     if (searchTerm) filters.search = searchTerm;
     if (selectedSubject) filters.subject = selectedSubject;
     if (selectedGrade) filters.grade = selectedGrade;
+    if (selectedDomain) filters.domain = selectedDomain;
     setSearchFilters(filters);
   };
 
@@ -31,6 +36,7 @@ export default function OutcomesPage() {
     setSearchTerm('');
     setSelectedSubject('');
     setSelectedGrade('');
+    setSelectedDomain('');
     setSearchFilters({});
   };
 
@@ -77,9 +83,10 @@ export default function OutcomesPage() {
     {} as Record<string, Outcome[]>,
   );
 
-  // Extract unique subjects and grades for filter dropdowns
-  const subjects = [...new Set(outcomes.map((o) => o.subject))];
+  // Extract unique subjects, grades, and domains for filter dropdowns
+  const subjects = [...new Set(outcomes.map((o) => o.subject))].sort();
   const grades = [...new Set(outcomes.map((o) => o.grade))].sort((a, b) => a - b);
+  const domains = [...new Set(outcomes.map((o) => o.domain).filter(Boolean))].sort();
 
   // Sort icon component
   const SortIcon = ({ field }: { field: keyof Outcome }) => {
@@ -92,7 +99,10 @@ export default function OutcomesPage() {
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Curriculum Outcomes</h1>
         <div className="flex space-x-2">
-          <a href="/coverage" className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
+          <a
+            href="/coverage"
+            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
             View Coverage Dashboard
           </a>
           <a href="/" className="px-4 py-2 bg-gray-200 rounded-md hover:bg-gray-300">
@@ -156,21 +166,64 @@ export default function OutcomesPage() {
               ))}
             </select>
           </div>
+
+          <div className="w-full md:w-auto">
+            <label htmlFor="domain" className="block text-sm font-medium text-gray-700 mb-1">
+              Domain
+            </label>
+            <select
+              id="domain"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              value={selectedDomain}
+              onChange={(e) => setSelectedDomain(e.target.value)}
+            >
+              <option value="">All Domains</option>
+              {domains.map((domain) => (
+                <option key={domain} value={domain}>
+                  {domain}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
-        <div className="flex justify-end gap-2">
-          <button
-            className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
-            onClick={handleReset}
-          >
-            Reset
-          </button>
-          <button
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-            onClick={handleSearch}
-          >
-            Search
-          </button>
+        <div className="flex justify-between items-center">
+          {/* View mode selector */}
+          <div className="flex gap-2 bg-white rounded-md border border-gray-300 p-1">
+            <button
+              className={`px-3 py-1 rounded ${viewMode === 'table' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+              onClick={() => setViewMode('table')}
+            >
+              Table
+            </button>
+            <button
+              className={`px-3 py-1 rounded ${viewMode === 'cards' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+              onClick={() => setViewMode('cards')}
+            >
+              Cards
+            </button>
+            <button
+              className={`px-3 py-1 rounded ${viewMode === 'details' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+              onClick={() => setViewMode('details')}
+            >
+              Details
+            </button>
+          </div>
+
+          <div className="flex gap-2">
+            <button
+              className="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+              onClick={handleReset}
+            >
+              Reset
+            </button>
+            <button
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+              onClick={handleSearch}
+            >
+              Search
+            </button>
+          </div>
         </div>
       </div>
 
@@ -178,95 +231,133 @@ export default function OutcomesPage() {
       {loading && <div className="text-center py-4">Loading outcomes...</div>}
       {error && <div className="text-red-600 bg-red-100 p-3 rounded mb-4">{error}</div>}
 
-      {/* Results - Table View */}
+      {/* Results */}
       {!loading && !error && (
         <>
           {sortedOutcomes.length === 0 ? (
             <div className="text-center py-4">No outcomes found matching your criteria.</div>
           ) : (
-            <div className="mb-8">
-              <h2 className="text-xl font-semibold mb-3">All Outcomes ({sortedOutcomes.length})</h2>
-              <div className="overflow-x-auto">
-                <table className="min-w-full bg-white border border-gray-200">
-                  <thead className="bg-gray-100">
-                    <tr>
-                      <th
-                        className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
-                        onClick={() => handleSort('code')}
-                      >
-                        Code <SortIcon field="code" />
-                      </th>
-                      <th
-                        className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
-                        onClick={() => handleSort('description')}
-                      >
-                        Description <SortIcon field="description" />
-                      </th>
-                      <th
-                        className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
-                        onClick={() => handleSort('subject')}
-                      >
-                        Subject <SortIcon field="subject" />
-                      </th>
-                      <th
-                        className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
-                        onClick={() => handleSort('grade')}
-                      >
-                        Grade <SortIcon field="grade" />
-                      </th>
-                      <th
-                        className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
-                        onClick={() => handleSort('domain')}
-                      >
-                        Domain <SortIcon field="domain" />
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedOutcomes.map((outcome) => (
-                      <tr key={outcome.id} className="hover:bg-gray-50">
-                        <td className="px-4 py-2 border font-mono">{outcome.code}</td>
-                        <td className="px-4 py-2 border">{outcome.description}</td>
-                        <td className="px-4 py-2 border">{outcome.subject}</td>
-                        <td className="px-4 py-2 border text-center">{outcome.grade}</td>
-                        <td className="px-4 py-2 border">{outcome.domain || '-'}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+            <>
+              <div className="mb-4">
+                <h2 className="text-xl font-semibold">All Outcomes ({sortedOutcomes.length})</h2>
               </div>
-            </div>
-          )}
 
-          {/* Group By Subject View */}
-          <div>
-            <h2 className="text-xl font-semibold mb-3">Outcomes by Subject</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {Object.entries(outcomesBySubject).map(([subject, subjectOutcomes]) => (
-                <div key={subject} className="border rounded-lg overflow-hidden">
-                  <div className="bg-blue-600 text-white px-4 py-2 font-semibold flex justify-between">
-                    <span>{subject}</span>
-                    <span>{subjectOutcomes.length} outcomes</span>
-                  </div>
-                  <div className="p-4">
-                    <div className="max-h-60 overflow-y-auto">
-                      {subjectOutcomes.map((outcome) => (
-                        <div key={outcome.id} className="mb-2 pb-2 border-b">
-                          <div className="font-mono text-sm">{outcome.code}</div>
-                          <div>{outcome.description}</div>
-                          {outcome.domain && (
-                            <div className="text-sm text-gray-600 mt-1">
-                              Domain: {outcome.domain}
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
+              {/* Table View */}
+              {viewMode === 'table' && (
+                <div className="mb-8">
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full bg-white border border-gray-200">
+                      <thead className="bg-gray-100">
+                        <tr>
+                          <th
+                            className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
+                            onClick={() => handleSort('code')}
+                          >
+                            Code <SortIcon field="code" />
+                          </th>
+                          <th
+                            className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
+                            onClick={() => handleSort('description')}
+                          >
+                            Description <SortIcon field="description" />
+                          </th>
+                          <th
+                            className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
+                            onClick={() => handleSort('subject')}
+                          >
+                            Subject <SortIcon field="subject" />
+                          </th>
+                          <th
+                            className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
+                            onClick={() => handleSort('grade')}
+                          >
+                            Grade <SortIcon field="grade" />
+                          </th>
+                          <th
+                            className="px-4 py-2 border cursor-pointer hover:bg-gray-200"
+                            onClick={() => handleSort('domain')}
+                          >
+                            Domain <SortIcon field="domain" />
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sortedOutcomes.map((outcome) => (
+                          <tr key={outcome.id} className="hover:bg-gray-50">
+                            <td className="px-4 py-2 border font-mono">
+                              <OutcomeTooltip outcome={outcome}>
+                                <span className="cursor-help border-b border-dotted border-gray-500">
+                                  {outcome.code}
+                                </span>
+                              </OutcomeTooltip>
+                            </td>
+                            <td className="px-4 py-2 border">{outcome.description}</td>
+                            <td className="px-4 py-2 border">{outcome.subject}</td>
+                            <td className="px-4 py-2 border text-center">{outcome.grade}</td>
+                            <td className="px-4 py-2 border">{outcome.domain || '-'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
                   </div>
                 </div>
-              ))}
-            </div>
-          </div>
+              )}
+
+              {/* Cards View (Group By Subject) */}
+              {viewMode === 'cards' && (
+                <div className="mb-8">
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {Object.entries(outcomesBySubject).map(([subject, subjectOutcomes]) => (
+                      <div
+                        key={subject}
+                        className="border rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                      >
+                        <div className="bg-blue-600 text-white px-4 py-2 font-semibold flex justify-between">
+                          <span>{subject}</span>
+                          <span>{subjectOutcomes.length} outcomes</span>
+                        </div>
+                        <div className="p-4">
+                          <div className="max-h-60 overflow-y-auto">
+                            {subjectOutcomes.map((outcome) => (
+                              <div key={outcome.id} className="mb-2 pb-2 border-b">
+                                <div className="font-mono text-sm">
+                                  <OutcomeTooltip outcome={outcome}>
+                                    <span className="cursor-help border-b border-dotted border-gray-500">
+                                      {outcome.code}
+                                    </span>
+                                  </OutcomeTooltip>
+                                </div>
+                                <div className="text-sm">{outcome.description}</div>
+                                <div className="flex flex-wrap text-xs text-gray-600 mt-1 gap-2">
+                                  {outcome.domain && (
+                                    <span className="bg-gray-100 px-2 py-0.5 rounded-full">
+                                      {outcome.domain}
+                                    </span>
+                                  )}
+                                  <span className="bg-blue-100 px-2 py-0.5 rounded-full">
+                                    Grade {outcome.grade}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Detailed View */}
+              {viewMode === 'details' && (
+                <div className="mb-8">
+                  {sortedOutcomes.map((outcome) => (
+                    <OutcomeDetail key={outcome.id} outcome={outcome} />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
- Add tooltips to outcome codes showing full details on hover
- Add domain filter to search options
- Implement multiple view modes: table, cards, and detail view
- Add expandable detail view for each outcome
- Improve styling and usability for better outcome exploration
- Group outcomes by subject with better visual organization

🤖 Generated with [Claude Code](https://claude.ai/code)