### PR TITLE
feat: complete Parent Communication Center implementation

### DIFF
--- a/AGENT-CASCADE-LOG.md
+++ b/AGENT-CASCADE-LOG.md
@@ -1,0 +1,43 @@
+# Agent CASCADE Development Log
+
+## Status: Working on Parent Communication Center
+
+**Started:** 2025-06-19
+**Worktree:** /Users/michaelmcisaac/GitHub/te2-cascade
+**Current Branch:** feat/parent-communication-center
+
+## Setup Complete
+
+- [x] Personal worktree created
+- [x] Dependencies installed
+- [x] Tests verified (with timeout issues, but tests are running)
+- [x] Task assignment received
+- [x] Feature branch created
+
+## Current Task: Parent Communication Center
+
+Implementing bilingual parent communication system with newsletters, messages, and export functionality.
+
+## Files I'm Working On
+
+- packages/database/prisma/schema.prisma
+- server/src/routes/parentMessage.ts
+- client/src/components/ParentMessageEditor.tsx
+- client/src/components/ParentMessagePreview.tsx
+- client/src/pages/WeeklyPlanner.tsx
+
+## Coordination Notes
+
+(Log any conflicts, dependencies, or coordination needs)
+
+-
+
+## Commits Made
+
+(Track your commits for merge coordination)
+
+-
+
+## Sync History
+
+- 2025-06-19: Pulled from origin/main (f91993d)

--- a/AGENT-CASCADE-LOG.md
+++ b/AGENT-CASCADE-LOG.md
@@ -36,7 +36,7 @@ Implementing bilingual parent communication system with newsletters, messages, a
 
 (Track your commits for merge coordination)
 
--
+- e861c0f: feat: add ActivitySelectorMulti component and tests
 
 ## Sync History
 

--- a/client/src/components/ActivitySelectorMulti.tsx
+++ b/client/src/components/ActivitySelectorMulti.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import { useActivities } from '../api';
+import { Activity } from '../types';
+
+interface Props {
+  selectedActivities: number[];
+  onSelectionChange: (activities: number[]) => void;
+}
+
+export function ActivitySelectorMulti({ selectedActivities, onSelectionChange }: Props) {
+  const { data: activities, isLoading } = useActivities();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [expandedMilestones, setExpandedMilestones] = useState<Set<number>>(new Set());
+
+  // Group activities by milestone
+  const activitiesByMilestone = React.useMemo(() => {
+    if (!activities) return new Map();
+
+    const grouped = new Map<
+      number,
+      { milestone: { id: number; title: string } | undefined; activities: Activity[] }
+    >();
+
+    activities.forEach((activity) => {
+      const milestoneId = activity.milestoneId;
+      if (!grouped.has(milestoneId)) {
+        grouped.set(milestoneId, {
+          milestone: activity.milestone,
+          activities: [],
+        });
+      }
+      grouped.get(milestoneId)!.activities.push(activity);
+    });
+
+    return grouped;
+  }, [activities]);
+
+  // Filter activities based on search
+  const filteredGroups = React.useMemo(() => {
+    if (!searchTerm) return activitiesByMilestone;
+
+    const filtered = new Map<
+      number,
+      { milestone: { id: number; title: string } | undefined; activities: Activity[] }
+    >();
+    const searchLower = searchTerm.toLowerCase();
+
+    activitiesByMilestone.forEach((group, milestoneId) => {
+      const filteredActivities = group.activities.filter(
+        (activity) =>
+          activity.title.toLowerCase().includes(searchLower) ||
+          activity.titleEn?.toLowerCase().includes(searchLower) ||
+          activity.titleFr?.toLowerCase().includes(searchLower) ||
+          group.milestone?.title.toLowerCase().includes(searchLower),
+      );
+
+      if (filteredActivities.length > 0) {
+        filtered.set(milestoneId, {
+          milestone: group.milestone,
+          activities: filteredActivities,
+        });
+      }
+    });
+
+    return filtered;
+  }, [activitiesByMilestone, searchTerm]);
+
+  const toggleActivity = (activityId: number) => {
+    const newSelection = selectedActivities.includes(activityId)
+      ? selectedActivities.filter((id) => id !== activityId)
+      : [...selectedActivities, activityId];
+    onSelectionChange(newSelection);
+  };
+
+  const toggleMilestone = (milestoneId: number) => {
+    if (expandedMilestones.has(milestoneId)) {
+      setExpandedMilestones((prev) => {
+        const next = new Set(prev);
+        next.delete(milestoneId);
+        return next;
+      });
+    } else {
+      setExpandedMilestones((prev) => new Set(prev).add(milestoneId));
+    }
+  };
+
+  const selectAllInMilestone = (milestoneId: number) => {
+    const group = filteredGroups.get(milestoneId);
+    if (!group) return;
+
+    const milestoneActivityIds = group.activities.map((a) => a.id);
+    const allSelected = milestoneActivityIds.every((id) => selectedActivities.includes(id));
+
+    if (allSelected) {
+      // Deselect all
+      onSelectionChange(selectedActivities.filter((id) => !milestoneActivityIds.includes(id)));
+    } else {
+      // Select all
+      const newSelection = [...new Set([...selectedActivities, ...milestoneActivityIds])];
+      onSelectionChange(newSelection);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="border border-gray-300 rounded-md p-4 min-h-[200px] flex items-center justify-center">
+        <div className="text-gray-500">Loading activities...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-gray-300 rounded-md">
+      {/* Search bar */}
+      <div className="p-3 border-b">
+        <input
+          type="text"
+          placeholder="Search activities..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full px-3 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {/* Activity list */}
+      <div className="max-h-[300px] overflow-y-auto">
+        {filteredGroups.size === 0 ? (
+          <div className="p-4 text-center text-gray-500">
+            {searchTerm ? 'No activities found matching your search.' : 'No activities available.'}
+          </div>
+        ) : (
+          Array.from(filteredGroups.entries()).map(([milestoneId, group]) => {
+            const milestoneActivityIds = group.activities.map((a) => a.id);
+            const selectedCount = milestoneActivityIds.filter((id) =>
+              selectedActivities.includes(id),
+            ).length;
+            const isExpanded = expandedMilestones.has(milestoneId);
+
+            return (
+              <div key={milestoneId} className="border-b last:border-b-0">
+                {/* Milestone header */}
+                <div
+                  className="px-3 py-2 bg-gray-50 hover:bg-gray-100 cursor-pointer flex items-center justify-between"
+                  onClick={() => toggleMilestone(milestoneId)}
+                >
+                  <div className="flex items-center space-x-2">
+                    <span className="text-gray-500">{isExpanded ? '▼' : '▶'}</span>
+                    <span className="font-medium text-gray-700">
+                      {group.milestone?.title || 'Uncategorized'}
+                    </span>
+                    <span className="text-sm text-gray-500">
+                      ({selectedCount}/{group.activities.length} selected)
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      selectAllInMilestone(milestoneId);
+                    }}
+                    className="text-xs text-blue-600 hover:text-blue-800 px-2 py-1"
+                  >
+                    {selectedCount === group.activities.length ? 'Deselect All' : 'Select All'}
+                  </button>
+                </div>
+
+                {/* Activities */}
+                {isExpanded && (
+                  <div className="bg-white">
+                    {group.activities.map((activity) => (
+                      <label
+                        key={activity.id}
+                        className="flex items-center px-6 py-2 hover:bg-gray-50 cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedActivities.includes(activity.id)}
+                          onChange={() => toggleActivity(activity.id)}
+                          className="mr-3"
+                        />
+                        <div className="flex-1">
+                          <div className="text-sm font-medium text-gray-700">{activity.title}</div>
+                          {activity.titleEn && activity.titleFr && (
+                            <div className="text-xs text-gray-500">
+                              {activity.titleEn} / {activity.titleFr}
+                            </div>
+                          )}
+                        </div>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="p-3 border-t bg-gray-50 text-sm text-gray-600">
+        {selectedActivities.length} activities selected
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ParentMessageEditor.tsx
+++ b/client/src/components/ParentMessageEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useCreateParentMessage, useUpdateParentMessage } from '../api';
 import { ParentMessage, ParentMessageInput } from '../types';
 import { OutcomeSelector } from './OutcomeSelector';
+import { ActivitySelectorMulti } from './ActivitySelectorMulti';
 import RichTextEditor from './RichTextEditor';
 
 interface Props {
@@ -273,23 +274,6 @@ export function ParentMessageEditor({ message, onSave, onCancel, prefillData }: 
           </button>
         </div>
       </form>
-    </div>
-  );
-}
-
-// Simple multi-select activity component
-function ActivitySelectorMulti({
-  selectedActivities,
-}: {
-  selectedActivities: number[];
-  onSelectionChange: (activities: number[]) => void;
-}) {
-  // This would need to be implemented to show available activities
-  // For now, just a placeholder
-  return (
-    <div className="border border-gray-300 rounded-md p-3 min-h-[100px]">
-      <p className="text-gray-500 text-sm">Activity selector component to be implemented</p>
-      <p className="text-xs text-gray-400 mt-1">Selected: {selectedActivities.length} activities</p>
     </div>
   );
 }

--- a/server/tests/parentMessage.test.ts
+++ b/server/tests/parentMessage.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { TestServer } from './test-server';
+import { authenticatedAgent } from './factories';
+import { prisma } from '../src/prisma';
+
+describe('Parent Message API', () => {
+  let server: TestServer;
+
+  beforeEach(async () => {
+    server = new TestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('POST /api/parent-messages', () => {
+    it('should create a new parent message', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const messageData = {
+        title: 'Winter Theme Newsletter',
+        timeframe: 'Week of Jan 12-19, 2026',
+        contentFr: "Cette semaine, nous avons exploré le thème de l'hiver...",
+        contentEn: 'This week, we explored the theme of winter...',
+        linkedOutcomeIds: [],
+        linkedActivityIds: [],
+      };
+
+      const response = await agent.post('/api/parent-messages').send(messageData).expect(201);
+
+      expect(response.body).toMatchObject({
+        id: expect.any(Number),
+        title: messageData.title,
+        timeframe: messageData.timeframe,
+        contentFr: messageData.contentFr,
+        contentEn: messageData.contentEn,
+      });
+    });
+
+    it('should create a parent message with linked outcomes and activities', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      // Create test data
+      const subject = await prisma.subject.create({
+        data: {
+          name: 'French',
+          userId: 1,
+        },
+      });
+
+      const milestone = await prisma.milestone.create({
+        data: {
+          title: 'Winter Vocabulary',
+          subjectId: subject.id,
+          userId: 1,
+        },
+      });
+
+      const activity = await prisma.activity.create({
+        data: {
+          title: 'Winter Words Practice',
+          milestoneId: milestone.id,
+          userId: 1,
+        },
+      });
+
+      const outcome = await prisma.outcome.create({
+        data: {
+          id: 'test-outcome-1',
+          subject: 'French',
+          grade: 1,
+          code: 'FR1.1',
+          description: 'Use winter vocabulary in sentences',
+        },
+      });
+
+      const messageData = {
+        title: 'Winter Theme Newsletter',
+        timeframe: 'Week of Jan 12-19, 2026',
+        contentFr: "Cette semaine, nous avons exploré le thème de l'hiver...",
+        contentEn: 'This week, we explored the theme of winter...',
+        linkedOutcomeIds: [outcome.id],
+        linkedActivityIds: [activity.id],
+      };
+
+      const response = await agent.post('/api/parent-messages').send(messageData).expect(201);
+
+      expect(response.body.linkedOutcomes).toHaveLength(1);
+      expect(response.body.linkedOutcomes[0].outcome.id).toBe(outcome.id);
+      expect(response.body.linkedActivities).toHaveLength(1);
+      expect(response.body.linkedActivities[0].activity.id).toBe(activity.id);
+    });
+
+    it('should validate required fields', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const invalidData = {
+        title: '', // Empty title
+        timeframe: 'Week 1',
+        contentFr: 'Content',
+        contentEn: 'Content',
+      };
+
+      const response = await agent.post('/api/parent-messages').send(invalidData).expect(400);
+
+      expect(response.body.error).toBeDefined();
+    });
+  });
+
+  describe('GET /api/parent-messages', () => {
+    it('should return all parent messages for the authenticated user', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      // Create test messages
+      await prisma.parentMessage.createMany({
+        data: [
+          {
+            userId: 1,
+            title: 'Newsletter 1',
+            timeframe: 'Week 1',
+            contentFr: 'Contenu 1',
+            contentEn: 'Content 1',
+          },
+          {
+            userId: 1,
+            title: 'Newsletter 2',
+            timeframe: 'Week 2',
+            contentFr: 'Contenu 2',
+            contentEn: 'Content 2',
+          },
+        ],
+      });
+
+      const response = await agent.get('/api/parent-messages').expect(200);
+
+      expect(response.body).toHaveLength(2);
+      expect(response.body[0].title).toBe('Newsletter 2'); // Most recent first
+      expect(response.body[1].title).toBe('Newsletter 1');
+    });
+
+    it('should not return messages from other users', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      // Create message for another user
+      await prisma.parentMessage.create({
+        data: {
+          userId: 999,
+          title: 'Other User Newsletter',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu',
+          contentEn: 'Content',
+        },
+      });
+
+      // Create message for current user
+      await prisma.parentMessage.create({
+        data: {
+          userId: 1,
+          title: 'My Newsletter',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu',
+          contentEn: 'Content',
+        },
+      });
+
+      const response = await agent.get('/api/parent-messages').expect(200);
+
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0].title).toBe('My Newsletter');
+    });
+  });
+
+  describe('GET /api/parent-messages/:id', () => {
+    it('should return a specific parent message', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const message = await prisma.parentMessage.create({
+        data: {
+          userId: 1,
+          title: 'Test Newsletter',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu test',
+          contentEn: 'Test content',
+        },
+      });
+
+      const response = await agent.get(`/api/parent-messages/${message.id}`).expect(200);
+
+      expect(response.body).toMatchObject({
+        id: message.id,
+        title: message.title,
+        timeframe: message.timeframe,
+        contentFr: message.contentFr,
+        contentEn: message.contentEn,
+      });
+    });
+
+    it('should return 404 for non-existent message', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      await agent.get('/api/parent-messages/999999').expect(404);
+    });
+
+    it('should not return messages from other users', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const message = await prisma.parentMessage.create({
+        data: {
+          userId: 999,
+          title: 'Other User Newsletter',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu',
+          contentEn: 'Content',
+        },
+      });
+
+      await agent.get(`/api/parent-messages/${message.id}`).expect(404);
+    });
+  });
+
+  describe('PUT /api/parent-messages/:id', () => {
+    it('should update a parent message', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const message = await prisma.parentMessage.create({
+        data: {
+          userId: 1,
+          title: 'Original Title',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu original',
+          contentEn: 'Original content',
+        },
+      });
+
+      const updateData = {
+        title: 'Updated Title',
+        contentEn: 'Updated content',
+      };
+
+      const response = await agent
+        .put(`/api/parent-messages/${message.id}`)
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        id: message.id,
+        title: updateData.title,
+        timeframe: message.timeframe,
+        contentFr: message.contentFr,
+        contentEn: updateData.contentEn,
+      });
+    });
+
+    it('should update linked outcomes and activities', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      // Create test data
+      const subject = await prisma.subject.create({
+        data: {
+          name: 'Math',
+          userId: 1,
+        },
+      });
+
+      const milestone = await prisma.milestone.create({
+        data: {
+          title: 'Numbers',
+          subjectId: subject.id,
+          userId: 1,
+        },
+      });
+
+      const activity1 = await prisma.activity.create({
+        data: {
+          title: 'Activity 1',
+          milestoneId: milestone.id,
+          userId: 1,
+        },
+      });
+
+      const activity2 = await prisma.activity.create({
+        data: {
+          title: 'Activity 2',
+          milestoneId: milestone.id,
+          userId: 1,
+        },
+      });
+
+      const message = await prisma.parentMessage.create({
+        data: {
+          userId: 1,
+          title: 'Test Newsletter',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu',
+          contentEn: 'Content',
+          linkedActivities: {
+            create: [{ activityId: activity1.id }],
+          },
+        },
+      });
+
+      const updateData = {
+        linkedActivityIds: [activity2.id],
+      };
+
+      const response = await agent
+        .put(`/api/parent-messages/${message.id}`)
+        .send(updateData)
+        .expect(200);
+
+      expect(response.body.linkedActivities).toHaveLength(1);
+      expect(response.body.linkedActivities[0].activity.id).toBe(activity2.id);
+    });
+  });
+
+  describe('DELETE /api/parent-messages/:id', () => {
+    it('should delete a parent message', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const message = await prisma.parentMessage.create({
+        data: {
+          userId: 1,
+          title: 'To Delete',
+          timeframe: 'Week 1',
+          contentFr: 'À supprimer',
+          contentEn: 'To delete',
+        },
+      });
+
+      await agent.delete(`/api/parent-messages/${message.id}`).expect(204);
+
+      // Verify deletion
+      const deletedMessage = await prisma.parentMessage.findUnique({
+        where: { id: message.id },
+      });
+      expect(deletedMessage).toBeNull();
+    });
+
+    it('should not delete messages from other users', async () => {
+      const agent = await authenticatedAgent(server.app);
+
+      const message = await prisma.parentMessage.create({
+        data: {
+          userId: 999,
+          title: 'Other User Newsletter',
+          timeframe: 'Week 1',
+          contentFr: 'Contenu',
+          contentEn: 'Content',
+        },
+      });
+
+      await agent.delete(`/api/parent-messages/${message.id}`).expect(404);
+
+      // Verify message still exists
+      const stillExists = await prisma.parentMessage.findUnique({
+        where: { id: message.id },
+      });
+      expect(stillExists).not.toBeNull();
+    });
+  });
+});

--- a/tests/e2e/parent-communication.spec.ts
+++ b/tests/e2e/parent-communication.spec.ts
@@ -1,0 +1,257 @@
+import { test, expect } from '@playwright/test';
+import { loginAsTestUser } from './helpers/auth-updated';
+import { waitForElement } from './helpers/ci-stability';
+
+test.describe('Parent Communication Center', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsTestUser(page);
+  });
+
+  test('should create a new parent newsletter from weekly planner', async ({ page }) => {
+    // Navigate to weekly planner
+    await page.goto('/weekly-planner');
+    await waitForElement(page, 'text=Weekly Planner');
+
+    // Click create newsletter button
+    await page.click('button:has-text("📰 Create Newsletter")');
+    await waitForElement(page, 'text=Create Parent Newsletter');
+
+    // Fill in newsletter details
+    const newsletterData = {
+      title: `Winter Theme Newsletter ${Date.now()}`,
+      timeframe: 'Week of Jan 12-19, 2026',
+      contentFr:
+        "Cette semaine, nous avons exploré le thème de l'hiver. Les élèves ont appris de nouveaux mots de vocabulaire et ont pratiqué leur prononciation.",
+      contentEn:
+        'This week, we explored the theme of winter. Students learned new vocabulary words and practiced their pronunciation.',
+    };
+
+    // Enter title
+    await page.fill('input[placeholder*="Exploring Winter"]', newsletterData.title);
+
+    // Set timeframe
+    await page.fill('input[placeholder*="Week of"]', newsletterData.timeframe);
+
+    // Enter French content
+    await page.click('button:has-text("🇫🇷 Français")');
+    const frenchEditor = page.locator('.ProseMirror').first();
+    await frenchEditor.click();
+    await frenchEditor.fill(newsletterData.contentFr);
+
+    // Switch to English and enter content
+    await page.click('button:has-text("🇬🇧 English")');
+    const englishEditor = page.locator('.ProseMirror').last();
+    await englishEditor.click();
+    await englishEditor.fill(newsletterData.contentEn);
+
+    // Save the newsletter
+    await page.click('button:has-text("Create Newsletter")');
+
+    // Wait for success message
+    await waitForElement(page, 'text=Newsletter created successfully');
+
+    // Verify modal closes
+    await expect(page.locator('text=Create Parent Newsletter')).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('should view and manage parent messages', async ({ page }) => {
+    // Navigate to parent messages page
+    await page.goto('/parent-messages');
+    await waitForElement(page, 'text=Parent Communications');
+
+    // Create a new message
+    await page.click('button:has-text("New Message")');
+    await waitForElement(page, 'text=Create Parent Newsletter');
+
+    const messageData = {
+      title: `Monthly Update ${Date.now()}`,
+      timeframe: 'January 2026',
+      contentFr: 'Mise à jour mensuelle pour les parents.',
+      contentEn: 'Monthly update for parents.',
+    };
+
+    await page.fill('input[placeholder*="Exploring Winter"]', messageData.title);
+    await page.fill('input[placeholder*="Week of"]', messageData.timeframe);
+
+    // Enter bilingual content
+    const frenchEditor = page.locator('.ProseMirror').first();
+    await frenchEditor.click();
+    await frenchEditor.fill(messageData.contentFr);
+
+    await page.click('button:has-text("🇬🇧 English")');
+    const englishEditor = page.locator('.ProseMirror').last();
+    await englishEditor.click();
+    await englishEditor.fill(messageData.contentEn);
+
+    await page.click('button:has-text("Create Newsletter")');
+    await waitForElement(page, `text=${messageData.title}`);
+
+    // Test preview functionality
+    await page.click(`text=${messageData.title}`);
+    await waitForElement(page, 'text=Version française');
+    await waitForElement(page, 'text=English Version');
+
+    // Test language toggle
+    await page.click('button:has-text("🇫🇷 Français")');
+    await expect(page.locator('text=English Version')).not.toBeVisible();
+    await expect(page.locator('text=Version française')).toBeVisible();
+
+    await page.click('button:has-text("Both Languages")');
+    await expect(page.locator('text=English Version')).toBeVisible();
+    await expect(page.locator('text=Version française')).toBeVisible();
+  });
+
+  test('should export parent message to different formats', async ({ page }) => {
+    // Create a message first
+    await page.goto('/parent-messages');
+    await page.click('button:has-text("New Message")');
+
+    const messageData = {
+      title: `Export Test ${Date.now()}`,
+      timeframe: 'Test Week',
+      contentFr: 'Contenu de test en français.',
+      contentEn: 'Test content in English.',
+    };
+
+    await page.fill('input[placeholder*="Exploring Winter"]', messageData.title);
+    await page.fill('input[placeholder*="Week of"]', messageData.timeframe);
+
+    const frenchEditor = page.locator('.ProseMirror').first();
+    await frenchEditor.click();
+    await frenchEditor.fill(messageData.contentFr);
+
+    await page.click('button:has-text("🇬🇧 English")');
+    const englishEditor = page.locator('.ProseMirror').last();
+    await englishEditor.click();
+    await englishEditor.fill(messageData.contentEn);
+
+    await page.click('button:has-text("Create Newsletter")');
+    await waitForElement(page, `text=${messageData.title}`);
+
+    // Open the message
+    await page.click(`text=${messageData.title}`);
+    await waitForElement(page, 'text=Version française');
+
+    // Test copy HTML functionality
+    await page.click('button:has-text("📋 Copy HTML")');
+    await waitForElement(page, 'text=HTML content copied');
+
+    // Test copy Markdown functionality
+    await page.click('button:has-text("📝 Copy Markdown")');
+    await waitForElement(page, 'text=Markdown content copied');
+
+    // Print/PDF test would open a new window, so we'll just verify the button exists
+    await expect(page.locator('button:has-text("📄 Print/PDF")')).toBeVisible();
+  });
+
+  test('should link activities and outcomes to parent message', async ({ page }) => {
+    // Navigate to parent messages
+    await page.goto('/parent-messages');
+    await page.click('button:has-text("New Message")');
+
+    // Fill basic info
+    await page.fill('input[placeholder*="Exploring Winter"]', `Linked Content Test ${Date.now()}`);
+    await page.fill('input[placeholder*="Week of"]', 'Test Week');
+
+    // Add content
+    const frenchEditor = page.locator('.ProseMirror').first();
+    await frenchEditor.click();
+    await frenchEditor.fill('Test avec contenu lié.');
+
+    // Open outcome selector
+    const outcomeSection = page.locator('text=Linked Outcomes').locator('..');
+    await outcomeSection.locator('input[type="text"]').click();
+
+    // Select an outcome if available
+    const outcomeOption = page.locator('[role="option"]').first();
+    if (await outcomeOption.isVisible({ timeout: 2000 })) {
+      await outcomeOption.click();
+    }
+
+    // Open activity selector
+    const activitySection = page.locator('text=Linked Activities').locator('..');
+    await activitySection.locator('input[placeholder*="Search activities"]').click();
+
+    // Expand a milestone if available
+    const milestoneHeader = page.locator('.bg-gray-50').first();
+    if (await milestoneHeader.isVisible({ timeout: 2000 })) {
+      await milestoneHeader.click();
+
+      // Select an activity
+      const activityCheckbox = page.locator('input[type="checkbox"]').first();
+      if (await activityCheckbox.isVisible({ timeout: 2000 })) {
+        await activityCheckbox.click();
+      }
+    }
+
+    // Save the message
+    await page.click('button:has-text("Create Newsletter")');
+
+    // Verify it saved successfully
+    await waitForElement(page, 'text=Linked Content Test');
+  });
+
+  test('should edit existing parent message', async ({ page }) => {
+    // Create a message first
+    await page.goto('/parent-messages');
+    await page.click('button:has-text("New Message")');
+
+    const originalTitle = `Edit Test Original ${Date.now()}`;
+    await page.fill('input[placeholder*="Exploring Winter"]', originalTitle);
+    await page.fill('input[placeholder*="Week of"]', 'Original Week');
+
+    const frenchEditor = page.locator('.ProseMirror').first();
+    await frenchEditor.click();
+    await frenchEditor.fill('Contenu original.');
+
+    await page.click('button:has-text("Create Newsletter")');
+    await waitForElement(page, `text=${originalTitle}`);
+
+    // Open the message
+    await page.click(`text=${originalTitle}`);
+    await waitForElement(page, 'button:has-text("Edit")');
+
+    // Click edit
+    await page.click('button:has-text("Edit")');
+    await waitForElement(page, 'text=Edit Newsletter');
+
+    // Update the title
+    const updatedTitle = `Edit Test Updated ${Date.now()}`;
+    await page.fill('input[value*="Edit Test Original"]', updatedTitle);
+
+    // Save changes
+    await page.click('button:has-text("Update Newsletter")');
+
+    // Verify update
+    await waitForElement(page, `text=${updatedTitle}`);
+    await expect(page.locator(`text=${originalTitle}`)).not.toBeVisible();
+  });
+
+  test('should delete parent message', async ({ page }) => {
+    // Create a message to delete
+    await page.goto('/parent-messages');
+    await page.click('button:has-text("New Message")');
+
+    const messageTitle = `Delete Test ${Date.now()}`;
+    await page.fill('input[placeholder*="Exploring Winter"]', messageTitle);
+    await page.fill('input[placeholder*="Week of"]', 'Delete Week');
+
+    const frenchEditor = page.locator('.ProseMirror').first();
+    await frenchEditor.click();
+    await frenchEditor.fill('À supprimer.');
+
+    await page.click('button:has-text("Create Newsletter")');
+    await waitForElement(page, `text=${messageTitle}`);
+
+    // Open the message
+    await page.click(`text=${messageTitle}`);
+    await waitForElement(page, 'button:has-text("Delete")');
+
+    // Delete with confirmation
+    page.on('dialog', (dialog) => dialog.accept());
+    await page.click('button:has-text("Delete")');
+
+    // Verify deletion
+    await expect(page.locator(`text=${messageTitle}`)).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/tests/e2e/parent-communication.spec.ts
+++ b/tests/e2e/parent-communication.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { loginAsTestUser } from './helpers/auth-updated';
+import { loginAsTestUser, DEFAULT_TEST_USER } from './helpers/auth-updated';
 import { waitForElement } from './helpers/ci-stability';
 
 test.describe('Parent Communication Center', () => {
   test.beforeEach(async ({ page }) => {
-    await loginAsTestUser(page);
+    await loginAsTestUser(page, DEFAULT_TEST_USER);
   });
 
   test('should create a new parent newsletter from weekly planner', async ({ page }) => {

--- a/tests/storage/auth.json
+++ b/tests/storage/auth.json
@@ -6,11 +6,11 @@
       "localStorage": [
         {
           "name": "token",
-          "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMyIsImlhdCI6MTc1MDI3Mzg3NiwiZXhwIjoxNzUwMjc3NDc2fQ.RYIt_4ajZ5d3hMaNTvLok3lwkKgXm7X51ju_DFuK_Mo"
+          "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxIiwiaWF0IjoxNzUwMjk1ODY5LCJleHAiOjE3NTAyOTk0Njl9.O3NGnZQrieZYFepRP856oxrMdGxgddQeyzt4vMusuOY"
         },
         {
           "name": "auth-token",
-          "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMyIsImlhdCI6MTc1MDI3Mzg3NiwiZXhwIjoxNzUwMjc3NDc2fQ.RYIt_4ajZ5d3hMaNTvLok3lwkKgXm7X51ju_DFuK_Mo"
+          "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxIiwiaWF0IjoxNzUwMjk1ODY5LCJleHAiOjE3NTAyOTk0Njl9.O3NGnZQrieZYFepRP856oxrMdGxgddQeyzt4vMusuOY"
         },
         {
           "name": "onboarded",
@@ -18,7 +18,7 @@
         },
         {
           "name": "user",
-          "value": "{\"id\":13,\"email\":\"teacher@example.com\",\"name\":\"Test Teacher\",\"role\":\"teacher\"}"
+          "value": "{\"id\":1,\"email\":\"teacher@example.com\",\"name\":\"Test Teacher\",\"role\":\"teacher\"}"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Completed the Parent Communication Center feature implementation by adding the missing ActivitySelectorMulti component and comprehensive tests.

## Changes Made

- Created `ActivitySelectorMulti` component for selecting multiple activities with:
  - Grouping by milestone with expandable/collapsible sections
  - Search functionality to filter activities
  - Select all/deselect all per milestone
  - Activity counter showing selected items
  
- Added comprehensive backend tests for all parent message API endpoints:
  - CREATE, READ, UPDATE, DELETE operations
  - User isolation (messages only visible to their creators)
  - Validation testing
  - Linked outcomes and activities testing

- Added E2E tests for parent communication workflows:
  - Creating newsletters from weekly planner
  - Managing messages (view, edit, delete)
  - Export functionality testing
  - Linking activities and outcomes

## Test Results

✅ All server tests passing (12/12)
✅ All linting checks passing
✅ No TypeScript errors

## Notes

The Parent Communication Center feature was already mostly implemented in the codebase. This PR completes the implementation by:
1. Replacing the placeholder ActivitySelectorMulti with a fully functional component
2. Adding missing test coverage

The feature enables teachers to:
- Create bilingual newsletters (French/English)
- Link messages to classroom activities and learning outcomes
- Export in multiple formats (PDF, HTML, Markdown)
- Manage parent communications from a central location

🤖 Generated with [Claude Code](https://claude.ai/code)