### PR TITLE
feat: Quick Plan button and Week View as default dashboard

### DIFF
--- a/client/src/pages/QuickLessonPage.tsx
+++ b/client/src/pages/QuickLessonPage.tsx
@@ -1,18 +1,27 @@
 
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { Breadcrumbs } from '../components/Breadcrumbs';
-import { useCreateETFOLessonPlan, useUnitPlans } from '../hooks/useETFOPlanning';
+import { useCreateETFOLessonPlan, useUnitPlans, useCurriculumExpectations } from '../hooks/useETFOPlanning';
 
 export function QuickLessonPage(): React.ReactElement {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const expectationId = searchParams.get('expectationId');
   const [isSubmitting, setIsSubmitting] = useState(false);
   
   // Get user's unit plans to allow selection
   const { data: unitPlans = [] } = useUnitPlans({});
   const createMutation = useCreateETFOLessonPlan();
+  
+  // Get expectation details if expectationId is provided
+  const { data: expectations = [], isLoading: expectationsLoading, isError: expectationsError } = useCurriculumExpectations({ grade: 1 });
+  const linkedExpectation = expectationId ? expectations.find(exp => exp.id === expectationId) : null;
+  
+  // Check if expectationId was provided but not found (after loading completes)
+  const hasInvalidExpectationId = expectationId && !linkedExpectation && !expectationsLoading && !expectationsError && expectations.length > 0;
 
   const [formData, setFormData] = useState({
     title: '',
@@ -31,8 +40,29 @@ export function QuickLessonPage(): React.ReactElement {
       forAdvanced: '',
       forELL: '',
       forIEP: ''
-    }
+    },
+    expectationIds: expectationId ? [expectationId] : []
   });
+  
+  // Update learning goals when expectation is linked
+  useEffect(() => {
+    if (linkedExpectation && !formData.learningGoals) {
+      setFormData(prev => ({
+        ...prev,
+        learningGoals: `Students will ${linkedExpectation.description.toLowerCase()}`
+      }));
+    }
+  }, [linkedExpectation, formData.learningGoals]);
+  
+  // Clear expectationIds if the provided ID is invalid
+  useEffect(() => {
+    if (hasInvalidExpectationId) {
+      setFormData(prev => ({
+        ...prev,
+        expectationIds: []
+      }));
+    }
+  }, [hasInvalidExpectationId]);
 
   const handleSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
@@ -62,11 +92,15 @@ export function QuickLessonPage(): React.ReactElement {
         materials: formData.materials.split('\n').filter(m => m.trim()),
         assessmentNotes: formData.assessmentNotes,
         isSubFriendly: formData.isSubFriendly,
-        differentiationStrategies: formData.differentiationStrategies
+        differentiationStrategies: formData.differentiationStrategies,
+        expectationIds: formData.expectationIds
       };
 
       await createMutation.mutateAsync(lessonData);
       toast.success('Quick lesson created successfully!');
+      
+      // Navigate back to curriculum page after success
+      navigate('/curriculum');
       
       // Reset form
       setFormData({
@@ -86,7 +120,8 @@ export function QuickLessonPage(): React.ReactElement {
           forAdvanced: '',
           forELL: '',
           forIEP: ''
-        }
+        },
+        expectationIds: []
       });
     } catch (error) {
       toast.error('Failed to create lesson. Please try again.');
@@ -154,6 +189,100 @@ export function QuickLessonPage(): React.ReactElement {
           borderRadius: '12px', 
           boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)' 
         }}>
+          {/* Linked Expectation Alert */}
+          {linkedExpectation && (
+            <div style={{
+              backgroundColor: '#f0f9ff',
+              border: '1px solid #3b82f6',
+              borderRadius: '8px',
+              padding: '16px',
+              marginBottom: '24px',
+              display: 'flex',
+              alignItems: 'start',
+              gap: '12px'
+            }}>
+              <span style={{ fontSize: '20px' }}>🎯</span>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: '600', color: '#1d4ed8', marginBottom: '4px' }}>
+                  Linked Curriculum Expectation
+                </div>
+                <div style={{ fontSize: '14px', color: '#1e40af', marginBottom: '4px' }}>
+                  <strong>{linkedExpectation.code}</strong> - {linkedExpectation.subject}
+                </div>
+                <div style={{ fontSize: '14px', color: '#3730a3' }}>
+                  {linkedExpectation.description}
+                </div>
+              </div>
+            </div>
+          )}
+          
+          {/* Invalid Expectation ID Warning */}
+          {hasInvalidExpectationId && (
+            <div style={{
+              backgroundColor: '#fef2f2',
+              border: '1px solid #ef4444',
+              borderRadius: '8px',
+              padding: '16px',
+              marginBottom: '24px',
+              display: 'flex',
+              alignItems: 'start',
+              gap: '12px'
+            }}>
+              <span style={{ fontSize: '20px' }}>⚠️</span>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: '600', color: '#dc2626', marginBottom: '4px' }}>
+                  Invalid Curriculum Expectation
+                </div>
+                <div style={{ fontSize: '14px', color: '#b91c1c' }}>
+                  The linked expectation ID could not be found. The lesson will be created without a curriculum link.
+                </div>
+              </div>
+            </div>
+          )}
+          
+          {/* Loading State for Expectations */}
+          {expectationId && expectationsLoading && (
+            <div style={{
+              backgroundColor: '#f3f4f6',
+              border: '1px solid #d1d5db',
+              borderRadius: '8px',
+              padding: '16px',
+              marginBottom: '24px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px'
+            }}>
+              <span style={{ fontSize: '20px' }}>⏳</span>
+              <div style={{ fontSize: '14px', color: '#6b7280' }}>
+                Loading curriculum expectation details...
+              </div>
+            </div>
+          )}
+          
+          {/* Error Loading Expectations */}
+          {expectationId && expectationsError && (
+            <div style={{
+              backgroundColor: '#fef2f2',
+              border: '1px solid #ef4444',
+              borderRadius: '8px',
+              padding: '16px',
+              marginBottom: '24px',
+              display: 'flex',
+              alignItems: 'start',
+              gap: '12px'
+            }}>
+              <span style={{ fontSize: '20px' }}>❌</span>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: '600', color: '#dc2626', marginBottom: '4px' }}>
+                  Error Loading Expectation
+                </div>
+                <div style={{ fontSize: '14px', color: '#b91c1c' }}>
+                  Failed to load curriculum expectations. The lesson will be created without a curriculum link.
+                </div>
+              </div>
+            </div>
+          )}
+          
           {/* Basic Information */}
           <div style={{ marginBottom: '30px' }}>
             <h2 style={{ fontSize: '20px', fontWeight: '600', color: '#374151', marginBottom: '20px' }}>

--- a/client/src/routing/routesConfig.tsx
+++ b/client/src/routing/routesConfig.tsx
@@ -168,11 +168,11 @@ export const plannerRoutes: RouteConfig[] = [
 export const protectedRoutes: RouteConfig[] = [
   {
     path: '/',
-    element: <Navigate replace to="/dashboard" />,
+    element: <Navigate replace to="/planner/week" />,
   },
   {
     path: '/dashboard',
-    element: ShowcaseDashboard,
+    element: <Navigate replace to="/planner/week" />,
   },
   {
     path: '/today',


### PR DESCRIPTION
## Summary
Implements two high-priority quick wins from GitHub issues #305 and #306 with minimal code changes and maximum impact.

## Features Implemented

### 1. Quick Plan Feature (#306)
- ✅ Quick Plan buttons exist on curriculum page for uncovered expectations
- ✅ Clicking button navigates to `/planner/quick-lesson?expectationId={id}`
- ✅ QuickLessonPage reads and validates expectation ID from URL
- ✅ Auto-populates learning goals from expectation description
- ✅ Shows visual indicator for linked expectation
- ✅ Includes comprehensive error handling:
  - Loading state while fetching expectations
  - Warning for invalid expectation IDs
  - Error state for failed API calls
- ✅ Navigates back to curriculum page after successful creation

### 2. Week View as Default Dashboard (#305)
- ✅ Root path `/` redirects to `/planner/week`
- ✅ Dashboard path `/dashboard` redirects to `/planner/week`
- ✅ Week View page fully functional with schedule display

## Technical Approach
- **Minimal changes:** Only 2 files modified
- **No new dependencies:** Uses existing hooks and components
- **No backend changes:** Leverages existing API endpoints
- **No database migrations:** Works with current schema
- **TypeScript compliant:** All changes pass type checking

## Testing Performed
- [x] TypeScript compilation passes (`npm run typecheck`)
- [x] Quick Plan buttons verified in SimpleCurriculumPage.tsx
- [x] Route configuration verified for redirects
- [x] Error handling tested for various edge cases
- [x] Week View page confirmed functional

## Files Changed
- `client/src/pages/QuickLessonPage.tsx` - Enhanced with expectation linking
- `client/src/routing/routesConfig.tsx` - Updated default redirects

## Next Steps
After merging, consider implementing:
- Substitute Plans Feature (#307)
- Quick Assessment Grid (#316)
- Lesson Notes/Reflections (#321)

🤖 Generated with Claude Code